### PR TITLE
fix(router): pass numpad keys through in Hangul mode

### DIFF
--- a/OngeulApp/Sources/HandleKeyDownRouter.swift
+++ b/OngeulApp/Sources/HandleKeyDownRouter.swift
@@ -87,6 +87,13 @@ func routeKeyDown(
         return .flushAndPassToSystem
     }
 
+    // 키패드(텐키) → flush 후 통과. 3벌식에서 숫자가 한글로 매핑되는 것을 막는다.
+    // .numericPad 플래그는 화살표 키에도 세트되므로 위에서 화살표를 먼저 걸러낸 뒤 검사.
+    // 안전을 위해 플래그와 키코드 범위를 함께 검사한다.
+    if modifiers.contains(.numericPad) && KeyCode.numpadKeys.contains(keyCode) {
+        return .flushAndPassToSystem
+    }
+
     // 일반 키 → 엔진에 위임
     if let chars = characters,
        let label = keyLabel(

--- a/OngeulApp/Sources/KeyCodes.swift
+++ b/OngeulApp/Sources/KeyCodes.swift
@@ -16,4 +16,11 @@ enum KeyCode {
     static let arrowRight: UInt16 = 124
     static let arrowDown: UInt16  = 125
     static let arrowUp: UInt16    = 126
+
+    /// 키패드(텐키) 키코드 집합. Enter(0x4C)는 제외 — 일반 Enter와 통합 처리.
+    /// kVK_ANSI_Keypad* (Decimal, Multiply, Plus, Clear, Divide, Minus, Equals, 0-9)
+    static let numpadKeys: Set<UInt16> = [
+        0x41, 0x43, 0x45, 0x47, 0x4B, 0x4E, 0x51,
+        0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58, 0x59, 0x5B, 0x5C,
+    ]
 }

--- a/OngeulTests/HandleKeyDownRouterTests.swift
+++ b/OngeulTests/HandleKeyDownRouterTests.swift
@@ -115,6 +115,62 @@ class HandleKeyDownRouterTests: XCTestCase {
         }
     }
 
+    func testNumpadDigits_flushAndPass() {
+        // 3벌식에서 numpad 숫자가 한글로 변환되지 않도록 시스템에 위임되어야 한다.
+        // kVK_ANSI_Keypad0..9 키코드 + .numericPad 플래그
+        let numpadDigits: [(UInt16, String)] = [
+            (0x52, "0"), (0x53, "1"), (0x54, "2"), (0x55, "3"), (0x56, "4"),
+            (0x57, "5"), (0x58, "6"), (0x59, "7"), (0x5B, "8"), (0x5C, "9"),
+        ]
+        for (keyCode, char) in numpadDigits {
+            let action = routeKeyDown(
+                keyCode: keyCode, characters: char,
+                modifiers: .numericPad, engineMode: .korean,
+                toggleKey: .rightCommand
+            )
+            XCTAssertEqual(action, .flushAndPassToSystem,
+                "Numpad key \(keyCode) (\(char)) should flush and pass")
+        }
+    }
+
+    func testNumpadOperators_flushAndPass() {
+        // kVK_ANSI_Keypad{Decimal, Multiply, Plus, Clear, Divide, Minus, Equals}
+        let numpadOps: [(UInt16, String)] = [
+            (0x41, "."), (0x43, "*"), (0x45, "+"), (0x47, ""),
+            (0x4B, "/"), (0x4E, "-"), (0x51, "="),
+        ]
+        for (keyCode, char) in numpadOps {
+            let action = routeKeyDown(
+                keyCode: keyCode, characters: char,
+                modifiers: .numericPad, engineMode: .korean,
+                toggleKey: .rightCommand
+            )
+            XCTAssertEqual(action, .flushAndPassToSystem,
+                "Numpad operator \(keyCode) should flush and pass")
+        }
+    }
+
+    func testNumpadEnter_stillEnter() {
+        // 키패드 Enter는 기존대로 .enter로 라우팅되어야 한다.
+        let action = routeKeyDown(
+            keyCode: KeyCode.numpadEnter, characters: "\u{03}",
+            modifiers: .numericPad, engineMode: .korean,
+            toggleKey: .rightCommand
+        )
+        XCTAssertEqual(action, .enter)
+    }
+
+    func testMainRowDigit_stillProcessed() {
+        // 일반 숫자행의 "1"은 .numericPad 플래그가 없으므로 엔진으로 전달되어야 한다.
+        // (3벌식에서 한글로 변환되는 정상 경로)
+        let action = routeKeyDown(
+            keyCode: 0x12, characters: "1",
+            modifiers: [], engineMode: .korean,
+            toggleKey: .rightCommand
+        )
+        XCTAssertEqual(action, .processKey(label: "1"))
+    }
+
     func testNormalKey() {
         let action = routeKeyDown(
             keyCode: 0x05, characters: "g",


### PR DESCRIPTION
## Summary
- In 3-beolsik layouts (`3-390`, `3-final`) digits `0`-`9` are mapped to Hangul jamo, so numpad input was being composed as Hangul instead of inserting digits.
- Route all numpad keys (except Enter, which is intentionally unified with main Enter) to `flushAndPassToSystem`.
- Guard with both `NSEvent.ModifierFlags.numericPad` and the `kVK_ANSI_Keypad*` keycode range. Arrow keys also carry `.numericPad`, but they're routed earlier in `routeKeyDown`, so this check is unambiguous by the time it runs.

## Test plan
- [x] `xcodebuild test -scheme OngeulTests -only-testing:OngeulTests/HandleKeyDownRouterTests` — 18 tests pass (4 new: numpad digits, numpad operators, numpad Enter regression, main-row digit regression).
- [ ] Manual: switch to 3-final layout, type numpad digits/operators — system inserts raw digits, no Hangul composition.
- [ ] Manual: mid-Hangul composition + numpad key — composition commits, then digit is inserted.
- [ ] Manual: numpad Enter still flushes composition and inserts newline.