### PR TITLE
fix: post-review cleanup (logging, debounce retry, version parse cap)

### DIFF
--- a/OngeulApp/Sources/InputSourceLock.swift
+++ b/OngeulApp/Sources/InputSourceLock.swift
@@ -22,6 +22,9 @@ final class InputSourceLock: NSObject {
     private let minimumInterval: CFAbsoluteTime = 0.3  // 300ms 디바운스
     private var activityToken: NSObjectProtocol?
     private var wakeTimer: Timer?
+    /// 디바운스 윈도우에 걸려 무시된 호출의 1회 재시도용 타이머.
+    /// 디바운스 직후 OS가 다시 ABC로 돌려놓는 race에서 사용자가 갇히는 것을 방지.
+    private var debounceRetryTimer: Timer?
 
     private override init() {
         super.init()
@@ -73,6 +76,9 @@ final class InputSourceLock: NSObject {
 
         wakeTimer?.invalidate()
         wakeTimer = nil
+
+        debounceRetryTimer?.invalidate()
+        debounceRetryTimer = nil
 
         if let token = activityToken {
             ProcessInfo.processInfo.endActivity(token)
@@ -132,14 +138,28 @@ final class InputSourceLock: NSObject {
     func verifyAndRecover(source: String = "notification") {
         guard isObserving else { return }
 
-        // 디바운스: 짧은 시간 내 반복 전환 방지
+        // 디바운스: 짧은 시간 내 반복 전환 방지.
+        // 윈도우 내 호출은 즉시 무시하되, 디바운스 직후 OS가 다시 ABC로 돌려놓는
+        // race에 대비해 1회 재시도를 예약한다 (사용자가 ABC에 갇히는 것 방지).
         let now = CFAbsoluteTimeGetCurrent()
-        guard now - lastSwitchTime > minimumInterval else { return }
+        let elapsed = now - lastSwitchTime
+        if elapsed <= minimumInterval {
+            if debounceRetryTimer == nil {
+                let delay = (minimumInterval - elapsed) + 0.05
+                let timer = Timer(timeInterval: delay, repeats: false) { [weak self] _ in
+                    self?.debounceRetryTimer = nil
+                    self?.verifyAndRecover(source: "debounce-retry")
+                }
+                RunLoop.main.add(timer, forMode: .common)
+                debounceRetryTimer = timer
+            }
+            return
+        }
 
         // 보안 입력 활성 시 (암호 필드 등) → 복귀하지 않음
         if IsSecureEventInputEnabled() {
             os_log("InputSourceLock: skip — secure input active (via %{public}@)",
-                   log: log, type: .debug, source)
+                   log: log, type: .info, source)
             return
         }
 
@@ -160,7 +180,7 @@ final class InputSourceLock: NSObject {
         ) as String
         if sourceType != kTISTypeKeyboardLayout as String {
             os_log("InputSourceLock: skip — non-keyboard-layout: %{public}@ (via %{public}@)",
-                   log: log, type: .debug, currentId, source)
+                   log: log, type: .info, currentId, source)
             return
         }
 

--- a/ongeul-update/src/version.rs
+++ b/ongeul-update/src/version.rs
@@ -2,7 +2,11 @@ use std::cmp::Ordering;
 
 /// base version (숫자 부분)만 비교. Greater/Less/Equal 반환.
 fn compare_base(a: &str, b: &str) -> Ordering {
-    let parse = |v: &str| -> Vec<u32> { v.split('.').filter_map(|s| s.parse().ok()).collect() };
+    // 컴포넌트 수를 cap하여 악의적/오류 버전 문자열의 unbounded 할당 방지.
+    // 실제 semver는 3~4 컴포넌트이므로 8개면 충분히 여유.
+    let parse = |v: &str| -> Vec<u32> {
+        v.split('.').take(8).filter_map(|s| s.parse().ok()).collect()
+    };
     let a_parts = parse(a);
     let b_parts = parse(b);
     let max_len = a_parts.len().max(b_parts.len());


### PR DESCRIPTION
## Summary

Three independent low-risk fixes from the post-review backlog, bundled because each is small and they share no semantic territory with each other or with #2.

- **L4 — `InputSourceLock` log level**: `verifyAndRecover()`'s skip paths (secure input active, non-keyboard-layout source) logged at \`.debug\`. Default \`log stream\` doesn't show debug, so users diagnosing \"why didn't my input switch back?\" saw silence. Promoted to \`.info\`.
- **N1 — debounce window retry**: same function's 300ms debounce silently dropped notifications inside the window. If the OS flipped back to ABC during that window, the user got stuck until the next external trigger. Now schedules a one-shot \`Timer\` to retry after the window closes. Timer is cleared in \`stop()\` and self-nilled after firing.
- **M6 — version string parse cap**: \`ongeul-update::compare_base\` did \`split('.').filter_map(...)\` without a cap. Pathological input would allocate unboundedly. Capped at 8 components — real semver is 3-4, this is generous.

#2 is unrelated and can land in either order.

## Test plan

- [x] \`cargo test -p ongeul-update\` — 8 passed
- [x] \`xcodebuild test\` — 78 passed
- [ ] Manual: \`log stream --predicate 'subsystem == \"io.github.hiking90.inputmethod.Ongeul\"'\` while focusing a password field — should now show the secure-input skip without \`--level debug\`
- [ ] Manual: trigger a TIS notification storm (multiple rapid input-source changes) and verify the debounce-retry fires once after the window

🤖 Generated with [Claude Code](https://claude.com/claude-code)