### PR TITLE
refactor(input): extract FocusStealCorrector with regression suite

### DIFF
--- a/OngeulApp/Sources/FocusStealAdapters.swift
+++ b/OngeulApp/Sources/FocusStealAdapters.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+// MARK: - Production adapters for FocusStealCorrector dependencies
+
+/// CGEventTap의 keyBuffer를 KeyEvidenceSource로 노출.
+final class CGEventTapKeyEvidence: KeyEvidenceSource {
+    func consumeKeys() -> [RecordedKey] {
+        let buffer = KeyEventTap.keyBuffer
+        KeyEventTap.keyBuffer = []
+        return buffer
+    }
+}
+
+/// DispatchQueue.main 기반 Scheduler.
+final class MainQueueScheduler: Scheduler {
+    func schedule(after delay: TimeInterval, _ work: @escaping () -> Void) -> ScheduledTask {
+        let item = DispatchWorkItem(block: work)
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: item)
+        return DispatchWorkItemTask(item: item)
+    }
+
+    func scheduleImmediate(_ work: @escaping () -> Void) -> ScheduledTask {
+        let item = DispatchWorkItem(block: work)
+        DispatchQueue.main.async(execute: item)
+        return DispatchWorkItemTask(item: item)
+    }
+}
+
+/// DispatchWorkItem을 ScheduledTask로 감싸는 wrapper.
+final class DispatchWorkItemTask: ScheduledTask {
+    private let item: DispatchWorkItem
+
+    init(item: DispatchWorkItem) {
+        self.item = item
+    }
+
+    func cancel() {
+        item.cancel()
+    }
+}

--- a/OngeulApp/Sources/FocusStealCorrector.swift
+++ b/OngeulApp/Sources/FocusStealCorrector.swift
@@ -1,0 +1,182 @@
+import Foundation
+import os.log
+
+private let log = OSLog(subsystem: "io.github.hiking90.inputmethod.Ongeul", category: "focusSteal")
+
+/// 포커스 탈취 교정:
+/// 입력창이 없는 상태에서 앱이 키를 가로채 영문을 삽입한 경우를 교정한다.
+///
+/// 1. startCorrection: 버퍼된 키를 확인, 조건 충족 시 한글 모드 강제 + 10ms 타이머 시작,
+///    버퍼링 모드 진입.
+/// 2. 10ms 동안 handle()을 거치는 키는 keyBuffer에 저장 (엔진 처리 안 함).
+/// 3. 10ms 후 synthetic backspace 전송 → 시스템이 영문자 삭제.
+/// 4. handle()이 backspace 수신 → backspace 카운트다운.
+/// 5. 모든 backspace 소비되면 async replay → 버퍼 키를 엔진에 전달하여 한글 조합.
+///
+/// 동시성: 모든 메서드는 메인 스레드에서 호출되어야 한다 (IMK + DispatchQueue.main).
+final class FocusStealCorrector {
+    weak var delegate: FocusStealDelegate?
+
+    private let evidence: KeyEvidenceSource
+    private let scheduler: Scheduler
+    private let mode: FocusStealModeController
+
+    // 상태
+    private var bufferingTask: ScheduledTask?
+    private var replayTask: ScheduledTask?
+    private var buffering = false
+    private var expectingBackspace = 0
+    private var replayPending = false
+    private var keyBuffer: [String] = []
+    private var preKeyCount = 0
+
+    init(evidence: KeyEvidenceSource, scheduler: Scheduler, mode: FocusStealModeController) {
+        self.evidence = evidence
+        self.scheduler = scheduler
+        self.mode = mode
+    }
+
+    // MARK: - Public API
+
+    /// activateServer에서 (조건 검사 후) 호출. 보정 절차를 시작한다.
+    /// evidence에서 키를 consume하여 검사하므로 호출자가 별도로 keyBuffer를
+    /// 비우지 않는다.
+    func startCorrection() {
+        clearState()
+
+        let buffer = evidence.consumeKeys()
+        guard let firstKey = buffer.first else { return }
+
+        let elapsed = CFAbsoluteTimeGetCurrent() - firstKey.timestamp
+        guard elapsed < 0.5 else {
+            os_log("focusSteal: skip — elapsed=%.3f > 0.5", log: log, type: .debug, elapsed)
+            return
+        }
+
+        // 한글 모드 강제 (activateApp이 복원한 모드와 무관).
+        // client 부착 여부와 무관하게 모드 자체는 변경; delegate가 client nil 가드.
+        if mode.currentMode != .korean {
+            let flushResult = mode.forceKoreanForReplay()
+            delegate?.focusStealApplyResult(flushResult)
+        }
+        // 아이콘 동기화 (delegate가 client nil 가드).
+        delegate?.focusStealSyncIconKorean()
+
+        buffering = true
+        keyBuffer = buffer.map { $0.character }
+        preKeyCount = buffer.count
+
+        os_log("focusSteal: buffering %d keys, elapsed=%.3f", log: log, type: .debug,
+               preKeyCount, elapsed)
+
+        bufferingTask = scheduler.schedule(after: 0.01) { [weak self] in
+            self?.fireBufferingTimeout()
+        }
+    }
+
+    /// activateServer/deactivateServer 진입 시 호출. 진행 중 작업 모두 취소.
+    func cancel() {
+        clearState()
+    }
+
+    /// handleKeyDown에서 가장 먼저 호출. 이 키를 corrector가 어떻게 다루는지 결정.
+    /// keyLabel은 controller가 NSEvent에서 추출한 결과 (printable이 아니면 nil).
+    func handle(keyCode: UInt16, keyLabel: String?) -> Handling {
+        // 1) Synthetic backspace 카운트다운: 우리가 post한 backspace의 echo.
+        if keyCode == KeyCode.backspace && expectingBackspace > 0 {
+            expectingBackspace -= 1
+            if expectingBackspace == 0 {
+                scheduleReplay()
+            }
+            return .syntheticBackspaceConsumed
+        }
+        // 2) 버퍼링 가드: 세 가지 타이밍 모두 흡수.
+        //    keyLabel이 nil(backspace/enter/arrow 등 non-printable)이어도 .consumed.
+        if buffering || expectingBackspace > 0 || replayPending {
+            if let label = keyLabel {
+                keyBuffer.append(label)
+            }
+            return .consumed
+        }
+        return .passThrough
+    }
+
+    /// handle()의 반환 타입.
+    enum Handling {
+        /// 일반 키가 보정에 흡수됨. handleKeyDown은 return true.
+        case consumed
+        /// 우리의 합성 backspace. handleKeyDown은 return false (시스템 통과).
+        case syntheticBackspaceConsumed
+        /// corrector와 무관. 정상 라우팅으로 진행.
+        case passThrough
+    }
+
+    // MARK: - Internal
+
+    /// 10ms 후 호출: 후발 키 확인 + synthetic backspace post.
+    private func fireBufferingTimeout() {
+        bufferingTask = nil
+        buffering = false
+
+        // CGEventTap에 기록된 후발 키 확인.
+        let lateKeys = evidence.consumeKeys()
+
+        // handle() 버퍼링 가드에서 소비된 키 수.
+        let imeConsumed = keyBuffer.count - preKeyCount
+        // 앱에 직접 입력된 키 수 (IME를 거치지 않은 키).
+        let appInserted = max(0, lateKeys.count - imeConsumed)
+
+        if appInserted > 0 {
+            // 앱에 입력된 키는 시간순으로 lateKeys 앞부분에 위치
+            // (IME 활성화 전 → 앱 직접 입력, IME 활성화 후 → handle() 소비).
+            let appKeys = lateKeys.prefix(appInserted).map { $0.character }
+            keyBuffer.insert(contentsOf: appKeys, at: preKeyCount)
+        }
+
+        let totalBackspaces = preKeyCount + appInserted
+        expectingBackspace = totalBackspaces
+
+        os_log("focusSteal: sending %d backspaces (pre=%d late=%d)",
+               log: log, type: .debug, totalBackspaces, preKeyCount, appInserted)
+
+        delegate?.focusStealPostSyntheticBackspaces(count: totalBackspaces)
+    }
+
+    /// 모든 backspace 소비 후 호출: 버퍼된 키를 엔진에 replay.
+    /// 예약 사이에 deactivateServer가 발생하면 replayTask가 cancel되어 실행되지 않는다.
+    /// 활성 앱이 바뀌었으면 (다른 client 부착) replay 포기.
+    private func scheduleReplay() {
+        replayPending = true
+        let targetBundleId = delegate?.focusStealCurrentBundleId
+        replayTask?.cancel()
+        replayTask = scheduler.scheduleImmediate { [weak self] in
+            guard let self else { return }
+            self.replayTask = nil
+            self.replayPending = false
+            let keys = self.keyBuffer
+            self.keyBuffer = []
+            guard !keys.isEmpty,
+                  self.delegate?.focusStealCurrentBundleId == targetBundleId,
+                  self.delegate?.focusStealHasAttachedClient == true
+            else { return }
+            for key in keys {
+                let result = self.mode.processKey(key: key)
+                self.delegate?.focusStealApplyResult(result)
+            }
+        }
+    }
+
+    /// 진행 중 작업 cancel + 모든 상태 리셋.
+    /// startCorrection 진입 시 및 외부 cancel() 시 호출.
+    private func clearState() {
+        bufferingTask?.cancel()
+        bufferingTask = nil
+        replayTask?.cancel()
+        replayTask = nil
+        buffering = false
+        expectingBackspace = 0
+        replayPending = false
+        keyBuffer = []
+        preKeyCount = 0
+    }
+}

--- a/OngeulApp/Sources/FocusStealProtocols.swift
+++ b/OngeulApp/Sources/FocusStealProtocols.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// 외부에서 기록된 키 증거 (CGEventTap.keyBuffer 같은).
+/// FocusStealCorrector가 초기 read + 10ms 후 후발 read에 사용.
+/// 테스트에서는 FakeKeyEvidence를 주입하여 결정론적 검증.
+protocol KeyEvidenceSource: AnyObject {
+    /// 버퍼를 반환하고 비운다.
+    func consumeKeys() -> [RecordedKey]
+}
+
+/// 시간 제어 가능한 스케줄러 추상화.
+/// Production: MainQueueScheduler (DispatchQueue.main).
+/// Tests: ManualScheduler (advance(by:)로 시간 제어).
+protocol Scheduler: AnyObject {
+    func schedule(after delay: TimeInterval, _ work: @escaping () -> Void) -> ScheduledTask
+    func scheduleImmediate(_ work: @escaping () -> Void) -> ScheduledTask
+}
+
+/// 스케줄러가 반환하는 취소 가능한 작업 핸들.
+protocol ScheduledTask: AnyObject {
+    func cancel()
+}
+
+/// 한글 엔진 인터페이스 (FocusStealCorrector가 필요로 하는 만큼만).
+/// Production: InputStateCoordinator가 채택.
+/// Tests: FakeModeController.
+protocol FocusStealModeController: AnyObject {
+    var currentMode: InputMode { get }
+    func forceKoreanForReplay() -> ProcessResult
+    func processKey(key: String) -> ProcessResult
+}
+
+/// FocusStealCorrector → 외부 (IMK client, CGEvent post) 부수효과 위임.
+/// OngeulInputController가 채택.
+protocol FocusStealDelegate: AnyObject {
+    /// 한글 모드 강제 / 리플레이 결과를 IMK client에 적용.
+    /// client가 부착되지 않은 상태에서 호출되면 no-op이어야 한다.
+    func focusStealApplyResult(_ result: ProcessResult)
+
+    /// 합성 backspace를 시스템에 post.
+    func focusStealPostSyntheticBackspaces(count: Int)
+
+    /// 한글 모드로 강제 전환됐으므로 메뉴바 아이콘 동기화.
+    /// client가 부착되지 않은 상태에서 호출되면 no-op이어야 한다.
+    func focusStealSyncIconKorean()
+
+    /// replay 시점에 현재 활성 앱 bundleId.
+    /// closure 캡처 시점과 비교하여 client identity 검증.
+    var focusStealCurrentBundleId: String? { get }
+
+    /// IMK client가 현재 부착되어 있는지.
+    var focusStealHasAttachedClient: Bool { get }
+}

--- a/OngeulApp/Sources/InputStateCoordinator.swift
+++ b/OngeulApp/Sources/InputStateCoordinator.swift
@@ -4,7 +4,7 @@ private let log = OSLog(subsystem: "io.github.hiking90.inputmethod.Ongeul", cate
 
 /// 상태 전이 로직 전담. Engine, PerAppModeStore, EnglishLockStore를 소유.
 /// UI 의존성 없음. KeyEventTap.currentInputMode 동기화는 CGEvent 레벨의 상태 동기화이므로 여기서 담당.
-final class InputStateCoordinator {
+final class InputStateCoordinator: FocusStealModeController {
     private let engine = HangulEngine()
     private let perAppStore = PerAppModeStore()
     private let lockStore = EnglishLockStore()
@@ -13,6 +13,9 @@ final class InputStateCoordinator {
     // MARK: - Read-only
 
     var mode: InputMode { engine.getMode() }
+
+    /// FocusStealModeController 채택. `mode`의 alias.
+    var currentMode: InputMode { engine.getMode() }
 
     func isLocked(_ bundleId: String?) -> Bool {
         guard let bundleId else { return false }

--- a/OngeulApp/Sources/KeyEventTap.swift
+++ b/OngeulApp/Sources/KeyEventTap.swift
@@ -14,10 +14,7 @@ class KeyEventTap {
     private static var toggleDetector = ToggleDetector()
 
     // Focus-steal correction: 키 버퍼 (activateServer에서 초기화)
-    struct RecordedKey {
-        let character: String
-        let timestamp: CFAbsoluteTime
-    }
+    // RecordedKey 정의는 RecordedKey.swift로 이동됨.
     static var keyBuffer: [RecordedKey] = []
     static var keyBufferWasKoreanMode = false
 

--- a/OngeulApp/Sources/OngeulInputController.swift
+++ b/OngeulApp/Sources/OngeulInputController.swift
@@ -358,13 +358,17 @@ class OngeulInputController: IMKInputController {
     // 현재 조합 중인 텍스트 (composedString 콜백용)
     private var currentComposingText: String?
 
-    // Focus-steal correction
-    private var focusStealWorkItem: DispatchWorkItem?
-    private var focusStealReplayWorkItem: DispatchWorkItem?
-    private var focusStealBuffering = false
-    private var focusStealExpectingBackspace = 0  // 남은 backspace 수
-    private var focusStealReplayPending = false   // async 리플레이 대기 중
-    private var focusStealKeyBuffer: [String] = []
+    // Focus-steal correction (FocusStealCorrector로 추출).
+    // 인스턴스는 lazy 초기화 — coordinator/KeyEventTap 의존성이 모두 준비된 후 사용.
+    private lazy var focusSteal: FocusStealCorrector = {
+        let c = FocusStealCorrector(
+            evidence: CGEventTapKeyEvidence(),
+            scheduler: MainQueueScheduler(),
+            mode: Self.coordinator
+        )
+        c.delegate = self
+        return c
+    }()
 
     #if DEBUG
     /// 테스트에서 Bundle.main 대신 사용할 레이아웃 디렉토리 URL
@@ -502,14 +506,7 @@ class OngeulInputController: IMKInputController {
         KeyEventTap.activeController = self
 
         // 이전 focus-steal 세션 초기화 (deactivateServer 없이 재호출되는 경우 대비)
-        focusStealWorkItem?.cancel()
-        focusStealWorkItem = nil
-        focusStealReplayWorkItem?.cancel()
-        focusStealReplayWorkItem = nil
-        focusStealBuffering = false
-        focusStealExpectingBackspace = 0
-        focusStealReplayPending = false
-        focusStealKeyBuffer = []
+        focusSteal.cancel()
 
         if !AXIsProcessTrusted() {
             if !Self.hasPromptedAccessibility {
@@ -578,7 +575,7 @@ class OngeulInputController: IMKInputController {
 
         if KeyEventTap.keyBufferWasKoreanMode, !KeyEventTap.keyBuffer.isEmpty,
            !coordinator.isLocked(bundleId) {
-            correctFocusSteal()
+            focusSteal.startCorrection()
         } else {
             KeyEventTap.keyBuffer = []
         }
@@ -595,14 +592,7 @@ class OngeulInputController: IMKInputController {
     }
 
     override func deactivateServer(_ sender: Any!) {
-        focusStealWorkItem?.cancel()
-        focusStealWorkItem = nil
-        focusStealReplayWorkItem?.cancel()
-        focusStealReplayWorkItem = nil
-        focusStealBuffering = false
-        focusStealExpectingBackspace = 0
-        focusStealReplayPending = false
-        focusStealKeyBuffer = []
+        focusSteal.cancel()
 
         // keyBuffer는 activateServer에서만 정리 (focus-steal 증거 보존)
 
@@ -806,149 +796,17 @@ class OngeulInputController: IMKInputController {
         }
     }
 
-    // MARK: - Private: Focus-Steal Correction
-
-    /// 포커스 탈취 교정:
-    /// 입력창이 없는 상태에서 앱이 키를 가로채 영문을 삽입한 경우를 교정한다.
-    /// 1. activateServer에서 버퍼 키 감지 → 10ms 타이머 시작, 키 버퍼링 모드 진입
-    /// 2. 10ms 동안 handleKeyDown의 키를 focusStealKeyBuffer에 저장 (엔진 처리 안 함)
-    /// 3. 10ms 후 synthetic backspace 전송 → 시스템이 영문자 삭제
-    /// 4. handleKeyDown에서 backspace 수신 → 버퍼 키를 엔진에 전달하여 한글 조합
-    private func correctFocusSteal() {
-        // 이전 focus-steal 세션의 잔여 상태 초기화 (재진입 방지)
-        focusStealWorkItem?.cancel()
-        focusStealWorkItem = nil
-        focusStealBuffering = false
-        focusStealExpectingBackspace = 0
-        focusStealReplayPending = false
-        focusStealKeyBuffer = []
-
-        let buffer = KeyEventTap.keyBuffer
-        KeyEventTap.keyBuffer = []
-
-        guard let firstKey = buffer.first else { return }
-
-        let elapsed = CFAbsoluteTimeGetCurrent() - firstKey.timestamp
-        guard elapsed < 0.5 else {
-            os_log("focusSteal: skip — elapsed=%.3f > 0.5", log: log, type: .debug, elapsed)
-            return
-        }
-
-        // 한글 모드 강제 (activateApp이 복원한 모드와 무관)
-        if coordinator.mode != .korean {
-            if let client = self.client() {
-                let flushResult = coordinator.forceKoreanForReplay()
-                applyResult(flushResult, to: client)
-            } else {
-                _ = coordinator.forceKoreanForReplay()
-            }
-        }
-
-        // 아이콘 동기화 — 한글 모드로 강제 전환되었으므로
-        if let client = self.client() {
-            client.selectMode(InputModeID.korean)
-        }
-
-        focusStealBuffering = true
-        focusStealKeyBuffer = buffer.map { $0.character }
-        let preKeyCount = buffer.count
-
-        os_log("focusSteal: buffering %d keys, elapsed=%.3f", log: log, type: .debug,
-               preKeyCount, elapsed)
-
-        // 10ms 후 backspace 전송
-        // 대기 중 추가로 타이핑된 키를 keyBuffer에서 확인하여 backspace 수를 보정한다.
-        // - handleKeyDown을 거친 키: focusStealKeyBuffer에 추가됨 (앱에 미삽입, return true)
-        // - handleKeyDown을 거치지 않은 키: 앱에 직접 삽입됨 → 추가 backspace 필요
-        focusStealWorkItem?.cancel()
-        let workItem = DispatchWorkItem { [weak self] in
-            guard let self else { return }
-            self.focusStealWorkItem = nil
-            self.focusStealBuffering = false
-
-            // CGEventTap에 기록된 후발 키 확인
-            let lateKeys = KeyEventTap.keyBuffer
-            KeyEventTap.keyBuffer = []
-
-            // handleKeyDown 버퍼링 가드에서 소비된 키 수
-            let imeConsumed = self.focusStealKeyBuffer.count - preKeyCount
-            // 앱에 직접 입력된 키 수 (IME를 거치지 않은 키)
-            let appInserted = max(0, lateKeys.count - imeConsumed)
-
-            if appInserted > 0 {
-                // 앱에 입력된 키는 시간순으로 lateKeys 앞부분에 위치
-                // (IME 활성화 전 → 앱 직접 입력, IME 활성화 후 → handleKeyDown 소비)
-                let appKeys = lateKeys.prefix(appInserted).map { $0.character }
-                self.focusStealKeyBuffer.insert(contentsOf: appKeys, at: preKeyCount)
-            }
-
-            let totalBackspaces = preKeyCount + appInserted
-            self.focusStealExpectingBackspace = totalBackspaces
-
-            os_log("focusSteal: sending %d backspaces (pre=%d late=%d)",
-                   log: log, type: .debug, totalBackspaces, preKeyCount, appInserted)
-
-            let src = CGEventSource(stateID: .hidSystemState)
-            for _ in 0..<totalBackspaces {
-                if let down = CGEvent(keyboardEventSource: src, virtualKey: KeyCode.backspace, keyDown: true) {
-                    down.post(tap: .cghidEventTap)
-                }
-                if let up = CGEvent(keyboardEventSource: src, virtualKey: KeyCode.backspace, keyDown: false) {
-                    up.post(tap: .cghidEventTap)
-                }
-            }
-        }
-        focusStealWorkItem = workItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.01, execute: workItem)
-    }
-
     // MARK: - Private: Key Processing
 
     private func handleKeyDown(_ event: NSEvent, client: any IMKTextInput) -> Bool {
-        // Focus-steal synthetic backspace: 시스템에 위임하여 영문자 삭제 후
-        // 마지막 backspace에서 버퍼의 모든 키를 엔진에 전달
-        if event.keyCode == KeyCode.backspace, focusStealExpectingBackspace > 0 {
-            focusStealExpectingBackspace -= 1
-            if focusStealExpectingBackspace == 0 {
-                // async 리플레이 예약. 버퍼 캡처를 async 시점까지 지연하여,
-                // backspace 소비 후 ~ async 실행 전에 도착하는 키도 포함시킨다.
-                // 예약 사이에 deactivateServer가 발생하면 work item을 cancel하여
-                // 다른 앱의 client로 키가 흘러가는 것을 방지한다.
-                focusStealReplayPending = true
-                let targetBundleId = currentBundleId
-                focusStealReplayWorkItem?.cancel()
-                let workItem = DispatchWorkItem { [weak self] in
-                    guard let self else { return }
-                    self.focusStealReplayWorkItem = nil
-                    self.focusStealReplayPending = false
-                    let keys = self.focusStealKeyBuffer
-                    self.focusStealKeyBuffer = []
-                    // 활성 앱이 바뀌었으면 리플레이 포기 (잘못된 client에 키가 가는 것 방지)
-                    guard !keys.isEmpty,
-                          self.currentBundleId == targetBundleId,
-                          let client: any IMKTextInput = self.client()
-                    else { return }
-                    for key in keys {
-                        let result = self.coordinator.processKey(key: key)
-                        self.applyResult(result, to: client)
-                    }
-                }
-                focusStealReplayWorkItem = workItem
-                DispatchQueue.main.async(execute: workItem)
-            }
-            return false
-        }
-
-        // Focus-steal 버퍼링: 엔진 처리 없이 키만 저장
-        // 세 가지 타이밍을 모두 커버한다:
-        //   1. focusStealBuffering: 타이머 대기 중 (correctFocusSteal 후 10ms 이내)
-        //   2. focusStealExpectingBackspace > 0: synthetic backspace 소비 대기 중
-        //   3. focusStealReplayPending: backspace 모두 소비 후 async 리플레이 대기 중
-        if focusStealBuffering || focusStealExpectingBackspace > 0 || focusStealReplayPending {
-            if let keyLabel = keyLabelFromEvent(event) {
-                focusStealKeyBuffer.append(keyLabel)
-            }
-            return true
+        // Focus-steal corrector에 먼저 위임. 가드 순서 보존:
+        //   1. synthetic backspace 카운트다운 → return false (시스템 통과)
+        //   2. buffering/expectingBackspace/replayPending 가드 → return true (소비)
+        //   3. corrector 무관 → 정상 처리 진행
+        switch focusSteal.handle(keyCode: event.keyCode, keyLabel: keyLabelFromEvent(event)) {
+        case .syntheticBackspaceConsumed: return false
+        case .consumed: return true
+        case .passThrough: break
         }
 
         // keyBuffer는 activateServer에서만 정리한다.
@@ -1148,4 +1006,33 @@ class OngeulInputController: IMKInputController {
             os_log("Failed to parse layout: %{public}@", log: log, type: .error, String(describing: error))
         }
     }
+}
+
+// MARK: - FocusStealDelegate
+
+extension OngeulInputController: FocusStealDelegate {
+    func focusStealApplyResult(_ result: ProcessResult) {
+        guard let client: any IMKTextInput = self.client() else { return }
+        applyResult(result, to: client)
+    }
+
+    func focusStealPostSyntheticBackspaces(count: Int) {
+        let src = CGEventSource(stateID: .hidSystemState)
+        for _ in 0..<count {
+            if let down = CGEvent(keyboardEventSource: src, virtualKey: KeyCode.backspace, keyDown: true) {
+                down.post(tap: .cghidEventTap)
+            }
+            if let up = CGEvent(keyboardEventSource: src, virtualKey: KeyCode.backspace, keyDown: false) {
+                up.post(tap: .cghidEventTap)
+            }
+        }
+    }
+
+    func focusStealSyncIconKorean() {
+        self.client()?.selectMode(InputModeID.korean)
+    }
+
+    var focusStealCurrentBundleId: String? { currentBundleId }
+
+    var focusStealHasAttachedClient: Bool { self.client() != nil }
 }

--- a/OngeulApp/Sources/RecordedKey.swift
+++ b/OngeulApp/Sources/RecordedKey.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Focus-steal correction에서 사용하는 키 기록.
+/// CGEventTap이 시스템 레벨에서 잡은 키와 해당 시각을 보관한다.
+struct RecordedKey {
+    let character: String
+    let timestamp: CFAbsoluteTime
+}

--- a/OngeulTests/FocusStealCorrectorTests.swift
+++ b/OngeulTests/FocusStealCorrectorTests.swift
@@ -1,0 +1,341 @@
+import XCTest
+
+/// FocusStealCorrector의 상태 머신, 타이밍 race, 라이프사이클 시나리오를
+/// 결정론적으로 검증한다. ManualScheduler를 통해 10ms 대기와 async replay를
+/// 동기적으로 제어한다.
+final class FocusStealCorrectorTests: XCTestCase {
+    private var evidence: FakeKeyEvidence!
+    private var scheduler: ManualScheduler!
+    private var mode: FakeModeController!
+    private var delegate: SpyFocusStealDelegate!
+    private var corrector: FocusStealCorrector!
+
+    override func setUp() {
+        super.setUp()
+        evidence = FakeKeyEvidence()
+        scheduler = ManualScheduler()
+        mode = FakeModeController()
+        delegate = SpyFocusStealDelegate()
+        corrector = FocusStealCorrector(
+            evidence: evidence,
+            scheduler: scheduler,
+            mode: mode
+        )
+        corrector.delegate = delegate
+    }
+
+    // MARK: - 유틸
+
+    /// 신선한 timestamp (elapsed < 0.5 통과).
+    /// corrector는 CFAbsoluteTimeGetCurrent()로 elapsed 측정하므로 wall clock 기준.
+    private func key(_ char: String, atOffset offset: TimeInterval = 0) -> RecordedKey {
+        RecordedKey(character: char, timestamp: CFAbsoluteTimeGetCurrent() + offset)
+    }
+
+    /// 활성 보정의 전형적 흐름(보정 시작 → 10ms 대기 → backspace 소비) 를 진행.
+    /// 입력: 초기 버퍼. 호출 후 expectingBackspace > 0 상태가 된다.
+    private func startAndAdvanceToBackspacePhase(initialBuffer: [RecordedKey],
+                                                 lateBuffer: [RecordedKey] = []) {
+        evidence.queuedBatches = [initialBuffer, lateBuffer]
+        corrector.startCorrection()
+        scheduler.advance(by: 0.01)  // 10ms 대기 종료
+    }
+
+    // MARK: - T1: Happy path
+
+    func testHappyPath_twoKeysReplayedAfterBackspaces() {
+        // 이미 한글 모드 — forceKorean 경로는 T13에서 별도 검증.
+        mode.currentMode = .korean
+        let buffer: [RecordedKey] = [key("d"), key("k")]
+        startAndAdvanceToBackspacePhase(initialBuffer: buffer)
+
+        // 모드는 유지, 아이콘 동기화는 항상 호출
+        XCTAssertEqual(mode.forceKoreanCallCount, 0)
+        XCTAssertEqual(mode.currentMode, .korean)
+        XCTAssertEqual(delegate.iconSyncCount, 1)
+
+        // backspace 2개 post
+        XCTAssertEqual(delegate.postedBackspacesCalls, [2])
+
+        // backspace 응답으로 카운트다운
+        XCTAssertEqual(corrector.handle(keyCode: KeyCode.backspace, keyLabel: nil),
+                       .syntheticBackspaceConsumed)
+        XCTAssertEqual(corrector.handle(keyCode: KeyCode.backspace, keyLabel: nil),
+                       .syntheticBackspaceConsumed)
+
+        // 마지막 backspace 후 immediate replay 예약 → run
+        scheduler.runImmediates()
+
+        // 2개 키가 mode.processKey로 흘러갔고 결과가 적용됨
+        XCTAssertEqual(mode.processedKeys, ["d", "k"])
+        XCTAssertEqual(delegate.appliedResults.count, 2)
+    }
+
+    // MARK: - T2: 빈 버퍼
+
+    func testEmptyBuffer_doesNothing() {
+        evidence.queuedBatches = [[]]
+        corrector.startCorrection()
+        XCTAssertEqual(scheduler.pendingTaskCount, 0)
+        XCTAssertEqual(delegate.postedBackspacesCalls, [])
+        XCTAssertEqual(mode.forceKoreanCallCount, 0)
+    }
+
+    // MARK: - T3: 500ms 초과한 키 → skip
+
+    func testStaleKeys_skip() {
+        // wall clock - 1.0초 (>0.5 임계값)
+        let staleKey = RecordedKey(character: "d", timestamp: CFAbsoluteTimeGetCurrent() - 1.0)
+        evidence.queuedBatches = [[staleKey]]
+        corrector.startCorrection()
+        XCTAssertEqual(scheduler.pendingTaskCount, 0)
+        XCTAssertEqual(delegate.postedBackspacesCalls, [])
+    }
+
+    // MARK: - T4: 10ms 대기 중 evidence에 후발 키 도착
+
+    func testLateAppKeys_addedToBackspaceCount() {
+        mode.currentMode = .korean
+        let initial: [RecordedKey] = [key("d"), key("k")]
+        // 후발 키 3개 — 모두 앱에 직접 입력된 것으로 처리됨 (IME 통과한 키 없음)
+        let late: [RecordedKey] = [key("a"), key("b"), key("c")]
+        startAndAdvanceToBackspacePhase(initialBuffer: initial, lateBuffer: late)
+
+        // preKeyCount=2, imeConsumed=0, appInserted=3 → totalBackspaces=5
+        XCTAssertEqual(delegate.postedBackspacesCalls, [5])
+
+        // 5개 backspace 응답
+        for _ in 0..<5 {
+            XCTAssertEqual(corrector.handle(keyCode: KeyCode.backspace, keyLabel: nil),
+                           .syntheticBackspaceConsumed)
+        }
+        scheduler.runImmediates()
+
+        // replay 순서: appKeys(["a","b","c"]) at preKeyCount=2 인덱스에 삽입 후
+        // ["d","k","a","b","c"] 순서로 processKey
+        XCTAssertEqual(mode.processedKeys, ["d", "k", "a", "b", "c"])
+    }
+
+    // MARK: - T5: 10ms 대기 중 handle()로 키 도착 → 흡수
+
+    func testKeyDuringBuffering_consumed() {
+        mode.currentMode = .korean
+        evidence.queuedBatches = [[key("d"), key("k")], []]
+        corrector.startCorrection()
+
+        // 10ms 대기 중 handle() 호출 — 흡수되어 .consumed
+        XCTAssertEqual(corrector.handle(keyCode: 38, keyLabel: "j"), .consumed)
+
+        // 10ms 진행
+        scheduler.advance(by: 0.01)
+
+        // preKeyCount=2, focusStealKeyBuffer.count=3, imeConsumed=1, late=0
+        // → appInserted=0, totalBackspaces=preKeyCount=2
+        XCTAssertEqual(delegate.postedBackspacesCalls, [2])
+    }
+
+    // MARK: - T6: backspace 카운트다운 중 추가 키 도착 → 흡수, replay에 포함
+
+    func testKeyDuringBackspaceCountdown_consumed() {
+        mode.currentMode = .korean
+        startAndAdvanceToBackspacePhase(initialBuffer: [key("d"), key("k")])
+        // backspace 1개 소비
+        _ = corrector.handle(keyCode: KeyCode.backspace, keyLabel: nil)
+
+        // 추가 키
+        XCTAssertEqual(corrector.handle(keyCode: 38, keyLabel: "j"), .consumed)
+
+        // 마지막 backspace 소비 → replay 예약
+        _ = corrector.handle(keyCode: KeyCode.backspace, keyLabel: nil)
+        scheduler.runImmediates()
+
+        // ["d","k","j"] 순서로 processKey
+        XCTAssertEqual(mode.processedKeys, ["d", "k", "j"])
+    }
+
+    // MARK: - T7: replay pending 중 키 도착 → 흡수
+
+    func testKeyDuringReplayPending_consumed() {
+        // 이 케이스는 ManualScheduler 특성상 어렵다 — scheduleImmediate 후
+        // runImmediates 호출 전까지가 "pending" 상태이지만, 보통 이 사이에
+        // handle()이 호출되는 시나리오. 직접 시뮬레이션.
+        mode.currentMode = .korean
+        startAndAdvanceToBackspacePhase(initialBuffer: [key("d"), key("k")])
+        // 모든 backspace 소비 → replay 예약됨
+        _ = corrector.handle(keyCode: KeyCode.backspace, keyLabel: nil)
+        _ = corrector.handle(keyCode: KeyCode.backspace, keyLabel: nil)
+
+        // 아직 runImmediates 안 함 → replayPending = true 상태
+        XCTAssertEqual(corrector.handle(keyCode: 38, keyLabel: "j"), .consumed)
+
+        // 이제 replay
+        scheduler.runImmediates()
+        XCTAssertEqual(mode.processedKeys, ["d", "k", "j"])
+    }
+
+    // MARK: - T8: 10ms 대기 중 cancel() → bufferingTask 취소
+
+    func testCancelDuringBuffering_noBackspacePosted() {
+        mode.currentMode = .korean
+        evidence.queuedBatches = [[key("d"), key("k")], []]
+        corrector.startCorrection()
+        XCTAssertEqual(scheduler.pendingTaskCount, 1)
+
+        corrector.cancel()
+        XCTAssertEqual(scheduler.pendingTaskCount, 0)
+
+        // 시간이 흘러도 backspace post 안 됨
+        scheduler.advance(by: 0.1)
+        XCTAssertEqual(delegate.postedBackspacesCalls, [])
+    }
+
+    // MARK: - T9: backspace expecting 중 cancel() → 카운트 0으로
+
+    func testCancelDuringBackspaceExpecting_replayNotTriggered() {
+        mode.currentMode = .korean
+        startAndAdvanceToBackspacePhase(initialBuffer: [key("d"), key("k")])
+
+        // backspace 1개 소비 후 cancel
+        _ = corrector.handle(keyCode: KeyCode.backspace, keyLabel: nil)
+        corrector.cancel()
+
+        // 추가 backspace는 corrector와 무관 (.passThrough)
+        XCTAssertEqual(corrector.handle(keyCode: KeyCode.backspace, keyLabel: nil),
+                       .passThrough)
+
+        // immediate run도 아무 영향 없음
+        scheduler.runImmediates()
+        XCTAssertEqual(mode.processedKeys, [])
+    }
+
+    // MARK: - T10: replay pending 중 cancel() → replay 미실행
+
+    func testCancelDuringReplayPending_noKeysReplayed() {
+        mode.currentMode = .korean
+        startAndAdvanceToBackspacePhase(initialBuffer: [key("d"), key("k")])
+        _ = corrector.handle(keyCode: KeyCode.backspace, keyLabel: nil)
+        _ = corrector.handle(keyCode: KeyCode.backspace, keyLabel: nil)
+        // replay 예약된 상태
+
+        corrector.cancel()
+        scheduler.runImmediates()
+
+        XCTAssertEqual(mode.processedKeys, [])
+        XCTAssertEqual(delegate.appliedResults, [])
+    }
+
+    // MARK: - T11: replay 시점에 bundleId 변경 → replay skip
+
+    func testReplayWithBundleIdChange_skipped() {
+        mode.currentMode = .korean
+        delegate.bundleId = "com.app.original"
+        startAndAdvanceToBackspacePhase(initialBuffer: [key("d"), key("k")])
+        _ = corrector.handle(keyCode: KeyCode.backspace, keyLabel: nil)
+        _ = corrector.handle(keyCode: KeyCode.backspace, keyLabel: nil)
+
+        // replay 예약 → fire 전에 bundleId 변경
+        delegate.bundleId = "com.app.other"
+        scheduler.runImmediates()
+
+        // processKey 미호출
+        XCTAssertEqual(mode.processedKeys, [])
+    }
+
+    // MARK: - T12: replay 시점에 client 미부착 → replay skip
+
+    func testReplayWithoutAttachedClient_skipped() {
+        mode.currentMode = .korean
+        startAndAdvanceToBackspacePhase(initialBuffer: [key("d"), key("k")])
+        _ = corrector.handle(keyCode: KeyCode.backspace, keyLabel: nil)
+        _ = corrector.handle(keyCode: KeyCode.backspace, keyLabel: nil)
+
+        // replay 예약 → client 비활성화
+        delegate.hasAttachedClient = false
+        scheduler.runImmediates()
+
+        XCTAssertEqual(mode.processedKeys, [])
+        XCTAssertEqual(delegate.appliedResults, [])
+    }
+
+    // MARK: - T13: 영문 모드 → forceKoreanForReplay 호출
+
+    func testEnglishMode_forcesKorean() {
+        mode.currentMode = .english
+        startAndAdvanceToBackspacePhase(initialBuffer: [key("d")])
+
+        XCTAssertEqual(mode.forceKoreanCallCount, 1)
+        XCTAssertEqual(mode.currentMode, .korean)
+        // forceKorean의 ProcessResult 1개 + 아이콘 sync
+        XCTAssertEqual(delegate.appliedResults.count, 1)
+        XCTAssertEqual(delegate.iconSyncCount, 1)
+    }
+
+    // MARK: - T14: 이미 한글 모드면 forceKorean 미호출
+
+    func testKoreanMode_doesNotForceKorean() {
+        mode.currentMode = .korean
+        startAndAdvanceToBackspacePhase(initialBuffer: [key("d")])
+
+        XCTAssertEqual(mode.forceKoreanCallCount, 0)
+        // forceKorean 호출 안 했으므로 applyResult도 그 분만큼 안 호출
+        // (아이콘 sync는 호출됨)
+        XCTAssertEqual(delegate.appliedResults, [])
+        XCTAssertEqual(delegate.iconSyncCount, 1)
+    }
+
+    // MARK: - T15: startCorrection 두 번 연속 호출 → 이전 cancel
+
+    func testStartCorrectionTwice_previousCancelled() {
+        mode.currentMode = .korean
+        // 1차
+        evidence.queuedBatches = [[key("d"), key("k")], []]
+        corrector.startCorrection()
+        XCTAssertEqual(scheduler.pendingTaskCount, 1)
+
+        // 2차 — 이전 task cancel, 새 task 시작
+        evidence.queuedBatches = [[key("j")], []]
+        corrector.startCorrection()
+        // cancelled task가 제거된 후 새 task 1개
+        XCTAssertEqual(scheduler.pendingTaskCount, 1)
+
+        // 시간 진행 → 2차 보정만 동작 (preKeyCount=1)
+        scheduler.advance(by: 0.01)
+        XCTAssertEqual(delegate.postedBackspacesCalls, [1])
+    }
+
+    // MARK: - T16: 가드 순서 — synthetic backspace가 일반 가드보다 우선
+
+    func testSyntheticBackspace_takesPrecedenceOverBufferingGuard() {
+        mode.currentMode = .korean
+        startAndAdvanceToBackspacePhase(initialBuffer: [key("d"), key("k")])
+
+        // expectingBackspace > 0인 상태에서 backspace → syntheticBackspaceConsumed
+        XCTAssertEqual(corrector.handle(keyCode: KeyCode.backspace, keyLabel: nil),
+                       .syntheticBackspaceConsumed)
+    }
+
+    // MARK: - T17: 버퍼링 중 keyLabel nil → .consumed but 버퍼 미변경
+
+    func testKeyDuringBuffering_nilLabel_consumedButNotBuffered() {
+        mode.currentMode = .korean
+        evidence.queuedBatches = [[key("d"), key("k")], []]
+        corrector.startCorrection()
+
+        // keyLabel nil (예: backspace as user key during 10ms wait)
+        XCTAssertEqual(corrector.handle(keyCode: KeyCode.backspace, keyLabel: nil),
+                       .consumed)
+
+        // 10ms 진행
+        scheduler.advance(by: 0.01)
+        // 버퍼는 여전히 ["d","k"] 만 (nil label은 append 안 됨)
+        // → preKeyCount=2, imeConsumed=0 (focusStealKeyBuffer.count=2 그대로),
+        //   late=0, appInserted=0, totalBackspaces=2
+        XCTAssertEqual(delegate.postedBackspacesCalls, [2])
+
+        // replay 시 ["d","k"] 만
+        _ = corrector.handle(keyCode: KeyCode.backspace, keyLabel: nil)
+        _ = corrector.handle(keyCode: KeyCode.backspace, keyLabel: nil)
+        scheduler.runImmediates()
+        XCTAssertEqual(mode.processedKeys, ["d", "k"])
+    }
+}

--- a/OngeulTests/FocusStealDoubles.swift
+++ b/OngeulTests/FocusStealDoubles.swift
@@ -1,0 +1,134 @@
+import Foundation
+
+// MARK: - FakeKeyEvidence
+
+/// 테스트 주입용 evidence: 호출 시 반환할 키 배열을 미리 enqueue해둔다.
+final class FakeKeyEvidence: KeyEvidenceSource {
+    /// consumeKeys()가 차례로 반환할 배열들. pop_front 동작.
+    var queuedBatches: [[RecordedKey]] = []
+    /// 호출 횟수 (검증용).
+    private(set) var consumeCallCount = 0
+
+    func consumeKeys() -> [RecordedKey] {
+        consumeCallCount += 1
+        if queuedBatches.isEmpty { return [] }
+        return queuedBatches.removeFirst()
+    }
+}
+
+// MARK: - ManualScheduler
+
+/// 시간을 명시적으로 advance(by:) 호출로 흐르게 하는 스케줄러.
+/// 모든 task는 main queue가 아닌 내부 우선순위 큐에 들어가며,
+/// advance가 호출되는 즉시 동기 실행된다.
+final class ManualScheduler: Scheduler {
+    private(set) var now: TimeInterval = 0
+
+    private final class Task: ScheduledTask {
+        let fireTime: TimeInterval
+        let work: () -> Void
+        var cancelled = false
+        init(fireTime: TimeInterval, work: @escaping () -> Void) {
+            self.fireTime = fireTime
+            self.work = work
+        }
+        func cancel() { cancelled = true }
+    }
+
+    private var pending: [Task] = []
+
+    /// 현재 큐에 있는(취소되지 않은) 작업 수.
+    var pendingTaskCount: Int { pending.filter { !$0.cancelled }.count }
+
+    func schedule(after delay: TimeInterval, _ work: @escaping () -> Void) -> ScheduledTask {
+        let task = Task(fireTime: now + delay, work: work)
+        pending.append(task)
+        return task
+    }
+
+    func scheduleImmediate(_ work: @escaping () -> Void) -> ScheduledTask {
+        // 즉시 실행이라도 advance를 강제하지 않는다 — `runImmediates()`로 별도 트리거.
+        let task = Task(fireTime: now, work: work)
+        pending.append(task)
+        return task
+    }
+
+    /// 시간을 진행시켜 fireTime <= now인 task들을 시간순으로 실행.
+    func advance(by interval: TimeInterval) {
+        now += interval
+        runDueTasks()
+    }
+
+    /// 시간 변동 없이 fireTime == now인 즉시 task들만 실행.
+    func runImmediates() {
+        runDueTasks()
+    }
+
+    private func runDueTasks() {
+        // 시간순 정렬 후 fireTime <= now인 것을 cancelled 체크하며 실행.
+        // 실행 중 새 task가 추가될 수 있으므로 loop.
+        while true {
+            pending.sort { $0.fireTime < $1.fireTime }
+            guard let idx = pending.firstIndex(where: { !$0.cancelled && $0.fireTime <= now }) else {
+                break
+            }
+            let task = pending.remove(at: idx)
+            task.work()
+        }
+    }
+}
+
+// MARK: - FakeModeController
+
+final class FakeModeController: FocusStealModeController {
+    var currentMode: InputMode = .english
+    var processKeyResult: (String) -> ProcessResult = { _ in
+        ProcessResult(committed: nil, composing: nil, handled: true)
+    }
+    var forceKoreanResult: ProcessResult = ProcessResult(committed: nil, composing: nil, handled: true)
+
+    private(set) var processedKeys: [String] = []
+    private(set) var forceKoreanCallCount = 0
+
+    func forceKoreanForReplay() -> ProcessResult {
+        forceKoreanCallCount += 1
+        currentMode = .korean
+        return forceKoreanResult
+    }
+
+    func processKey(key: String) -> ProcessResult {
+        processedKeys.append(key)
+        return processKeyResult(key)
+    }
+}
+
+// MARK: - SpyFocusStealDelegate
+
+final class SpyFocusStealDelegate: FocusStealDelegate {
+    var bundleId: String? = "com.test.app"
+    var hasAttachedClient: Bool = true
+
+    private(set) var appliedResults: [ProcessResult] = []
+    private(set) var postedBackspacesCalls: [Int] = []
+    private(set) var iconSyncCount = 0
+
+    func focusStealApplyResult(_ result: ProcessResult) {
+        // 실제 controller 구현이 client nil 시 no-op이므로 동일하게 흉내.
+        if hasAttachedClient {
+            appliedResults.append(result)
+        }
+    }
+
+    func focusStealPostSyntheticBackspaces(count: Int) {
+        postedBackspacesCalls.append(count)
+    }
+
+    func focusStealSyncIconKorean() {
+        if hasAttachedClient {
+            iconSyncCount += 1
+        }
+    }
+
+    var focusStealCurrentBundleId: String? { bundleId }
+    var focusStealHasAttachedClient: Bool { hasAttachedClient }
+}

--- a/OngeulTests/FocusStealTests.swift
+++ b/OngeulTests/FocusStealTests.swift
@@ -23,7 +23,7 @@ class FocusStealTests: XCTestCase {
 
         // 첫 키 추가 시 koreanMode 기록
         KeyEventTap.keyBuffer.append(
-            KeyEventTap.RecordedKey(character: "j", timestamp: CFAbsoluteTimeGetCurrent())
+            RecordedKey(character: "j", timestamp: CFAbsoluteTimeGetCurrent())
         )
         if KeyEventTap.keyBuffer.count == 1 {
             KeyEventTap.keyBufferWasKoreanMode = (KeyEventTap.currentInputMode == .korean)
@@ -37,7 +37,7 @@ class FocusStealTests: XCTestCase {
         KeyEventTap.keyBuffer = []
 
         KeyEventTap.keyBuffer.append(
-            KeyEventTap.RecordedKey(character: "j", timestamp: CFAbsoluteTimeGetCurrent())
+            RecordedKey(character: "j", timestamp: CFAbsoluteTimeGetCurrent())
         )
         if KeyEventTap.keyBuffer.count == 1 {
             KeyEventTap.keyBufferWasKoreanMode = (KeyEventTap.currentInputMode == .korean)
@@ -51,7 +51,7 @@ class FocusStealTests: XCTestCase {
     func testBufferResetsWhenFirstKeyOlderThan200ms() {
         let staleTime = CFAbsoluteTimeGetCurrent() - 0.3  // 300ms ago
         KeyEventTap.keyBuffer = [
-            KeyEventTap.RecordedKey(character: "j", timestamp: staleTime)
+            RecordedKey(character: "j", timestamp: staleTime)
         ]
 
         // CGEventTap의 리셋 로직 재현
@@ -66,7 +66,7 @@ class FocusStealTests: XCTestCase {
     func testBufferKeepsWhenFirstKeyWithin200ms() {
         let recentTime = CFAbsoluteTimeGetCurrent() - 0.05  // 50ms ago
         KeyEventTap.keyBuffer = [
-            KeyEventTap.RecordedKey(character: "j", timestamp: recentTime)
+            RecordedKey(character: "j", timestamp: recentTime)
         ]
 
         let now = CFAbsoluteTimeGetCurrent()
@@ -82,7 +82,7 @@ class FocusStealTests: XCTestCase {
     func testFocusStealCondition_koreanAndNotEmpty_shouldActivate() {
         KeyEventTap.keyBufferWasKoreanMode = true
         KeyEventTap.keyBuffer = [
-            KeyEventTap.RecordedKey(character: "j", timestamp: CFAbsoluteTimeGetCurrent())
+            RecordedKey(character: "j", timestamp: CFAbsoluteTimeGetCurrent())
         ]
 
         let shouldActivate = KeyEventTap.keyBufferWasKoreanMode && !KeyEventTap.keyBuffer.isEmpty
@@ -92,7 +92,7 @@ class FocusStealTests: XCTestCase {
     func testFocusStealCondition_englishMode_shouldNotActivate() {
         KeyEventTap.keyBufferWasKoreanMode = false
         KeyEventTap.keyBuffer = [
-            KeyEventTap.RecordedKey(character: "j", timestamp: CFAbsoluteTimeGetCurrent())
+            RecordedKey(character: "j", timestamp: CFAbsoluteTimeGetCurrent())
         ]
 
         let shouldActivate = KeyEventTap.keyBufferWasKoreanMode && !KeyEventTap.keyBuffer.isEmpty
@@ -110,7 +110,7 @@ class FocusStealTests: XCTestCase {
     // MARK: - Elapsed 체크 (500ms 타임아웃)
 
     func testElapsedCheck_withinThreshold_shouldProceed() {
-        let recentKey = KeyEventTap.RecordedKey(
+        let recentKey = RecordedKey(
             character: "j", timestamp: CFAbsoluteTimeGetCurrent() - 0.1
         )
         let elapsed = CFAbsoluteTimeGetCurrent() - recentKey.timestamp
@@ -118,7 +118,7 @@ class FocusStealTests: XCTestCase {
     }
 
     func testElapsedCheck_beyondThreshold_shouldSkip() {
-        let staleKey = KeyEventTap.RecordedKey(
+        let staleKey = RecordedKey(
             character: "j", timestamp: CFAbsoluteTimeGetCurrent() - 1.0
         )
         let elapsed = CFAbsoluteTimeGetCurrent() - staleKey.timestamp
@@ -130,8 +130,8 @@ class FocusStealTests: XCTestCase {
     func testMultipleKeysAccumulateInBuffer() {
         let now = CFAbsoluteTimeGetCurrent()
         KeyEventTap.keyBuffer = [
-            KeyEventTap.RecordedKey(character: "j", timestamp: now),
-            KeyEventTap.RecordedKey(character: "b", timestamp: now + 0.05),
+            RecordedKey(character: "j", timestamp: now),
+            RecordedKey(character: "b", timestamp: now + 0.05),
         ]
 
         XCTAssertEqual(KeyEventTap.keyBuffer.count, 2)
@@ -142,9 +142,9 @@ class FocusStealTests: XCTestCase {
     func testBufferMapToCharacters() {
         let now = CFAbsoluteTimeGetCurrent()
         KeyEventTap.keyBuffer = [
-            KeyEventTap.RecordedKey(character: "j", timestamp: now),
-            KeyEventTap.RecordedKey(character: "b", timestamp: now + 0.03),
-            KeyEventTap.RecordedKey(character: "s", timestamp: now + 0.06),
+            RecordedKey(character: "j", timestamp: now),
+            RecordedKey(character: "b", timestamp: now + 0.03),
+            RecordedKey(character: "s", timestamp: now + 0.06),
         ]
 
         let characters = KeyEventTap.keyBuffer.map { $0.character }


### PR DESCRIPTION
## Summary

Extracts the focus-steal state machine from \`OngeulInputController\` into a dedicated \`FocusStealCorrector\` class, and adds 17 deterministic regression tests covering race scenarios the existing 78 tests don't reach.

**Base branch: \`fix/post-review-hardening\` (PR #2)** — this depends on the focus-steal hardening that lives there (H3 replay WorkItem, N5 forceKoreanForReplay signature). Will be rebased onto main once #2 lands.

## What changes

Three commits, each a clean unit:

1. **\`refactor: extract RecordedKey to top-level type\`** — Moves the \`RecordedKey\` struct out of \`KeyEventTap\` so it can be owned by the corrector without coupling to that class. Mechanical rename of 13 test references.

2. **\`refactor: extract FocusStealCorrector\`** — The 86-line \`correctFocusSteal()\` method, six instance properties, the lifecycle cleanup in \`activateServer\`/\`deactivateServer\`, and the focus-steal guards in \`handleKeyDown\` all move into \`FocusStealCorrector\`. The controller adopts \`FocusStealDelegate\` to receive side-effect callbacks. No behavior change; 78 existing tests pass.

3. **\`test: add FocusStealCorrector regression suite\`** — 17 new tests + test doubles (\`ManualScheduler\`, \`FakeKeyEvidence\`, \`FakeModeController\`, \`SpyFocusStealDelegate\`).

## Design

The corrector depends on three injectable protocols:

- \`KeyEvidenceSource\` — abstracts the external key buffer (\`CGEventTap\` in production)
- \`Scheduler\` — abstracts time-based scheduling (\`DispatchQueue.main\` in production, \`ManualScheduler\` in tests)
- \`FocusStealModeController\` — the hangul engine surface (\`InputStateCoordinator\` adopts it)

The controller becomes the \`FocusStealDelegate\`, exposing \`applyResult\`, \`postSyntheticBackspaces\`, \`syncIconKorean\`, \`currentBundleId\`, and \`hasAttachedClient\`. This keeps IMK/CGEvent specifics out of the corrector while preserving the existing call sites.

## Regression scenarios covered

| # | Scenario |
|---|---|
| T1 | Happy path: 2 keys → 10ms → 2 backspaces → replay |
| T2 | Empty buffer: no-op |
| T3 | Stale keys (>500ms): skip |
| T4 | Late keys via evidence: included in backspace count |
| T5-T7 | Keys via \`handle()\` during buffering / backspace / replay-pending: consumed |
| T8-T10 | \`cancel()\` at each phase: no orphaned work |
| T11 | bundleId change between enqueue and replay dispatch: skipped (PR #2 H3 regression test) |
| T12 | Detached client at replay: skipped |
| T13 | english→korean force path |
| T14 | Already-korean: no force |
| T15 | Double \`startCorrection\`: previous cancelled |
| T16 | Synthetic backspace precedence over buffering guard |
| T17 | nil keyLabel during buffering: consumed but not buffered |

## Stats

| | Lines |
|---|---|
| New files | +800 (3 prod, 2 test) |
| \`OngeulInputController.swift\` | -160 / +55 |
| Test count | 78 → 95 |

## Test plan

- [x] \`xcodebuild test\` — 95 passed
- [x] \`./scripts/build.sh --skip-bindgen\` — successful
- [ ] Manual: install IME and verify focus-steal corrects English keystrokes leaking into a new text field (Safari address bar, Mail composition)
- [ ] Manual: verify normal Korean typing unaffected
- [ ] Manual: verify mode toggle (Right Cmd / Shift+Space) unaffected
- [ ] Manual: verify English Lock toggle unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)