### PR TITLE
fix(input): debounce selectMode to eliminate keystroke dispatch stall

### DIFF
--- a/OngeulApp/Sources/OngeulInputController.swift
+++ b/OngeulApp/Sources/OngeulInputController.swift
@@ -363,7 +363,7 @@ class OngeulInputController: IMKInputController {
     // 추가 입력이 없을 때 selectMode를 호출한다.
     private var pendingSelectModeId: String?
     private var pendingSelectModeTask: DispatchWorkItem?
-    private static let selectModeIdleInterval: TimeInterval = 0.3
+    private static let selectModeIdleInterval: TimeInterval = 0.6
 
     // Focus-steal correction (FocusStealCorrector로 추출).
     // 인스턴스는 lazy 초기화 — coordinator/KeyEventTap 의존성이 모두 준비된 후 사용.

--- a/OngeulApp/Sources/OngeulInputController.swift
+++ b/OngeulApp/Sources/OngeulInputController.swift
@@ -358,6 +358,13 @@ class OngeulInputController: IMKInputController {
     // 현재 조합 중인 텍스트 (composedString 콜백용)
     private var currentComposingText: String?
 
+    // SelectMode 디바운스: 토글 직후 macOS IMK가 ~100–350ms 동안 keystroke dispatch를
+    // stall하는 문제를 우회하기 위해, 마지막 keystroke로부터 selectModeIdleInterval 동안
+    // 추가 입력이 없을 때 selectMode를 호출한다.
+    private var pendingSelectModeId: String?
+    private var pendingSelectModeTask: DispatchWorkItem?
+    private static let selectModeIdleInterval: TimeInterval = 0.3
+
     // Focus-steal correction (FocusStealCorrector로 추출).
     // 인스턴스는 lazy 초기화 — coordinator/KeyEventTap 의존성이 모두 준비된 후 사용.
     private lazy var focusSteal: FocusStealCorrector = {
@@ -555,7 +562,9 @@ class OngeulInputController: IMKInputController {
             applyEffect(effect, to: client)
         }
 
-        // 아이콘 동기화 — applyEffect의 modeChanged와 무관하게 항상 수행
+        // 아이콘 동기화 — applyEffect의 modeChanged와 무관하게 항상 수행.
+        // 이전 client에 대한 보류된 selectMode는 stale이므로 폐기.
+        cancelSelectMode()
         if let client = sender as? (any IMKTextInput) {
             let modeId = InputModeID.from(coordinator.mode)
             client.selectMode(modeId)
@@ -593,6 +602,8 @@ class OngeulInputController: IMKInputController {
 
     override func deactivateServer(_ sender: Any!) {
         focusSteal.cancel()
+        // 보류된 selectMode를 지금 호출 — 입력은 끝났으니 stall이 더 이상 의미 없다.
+        flushSelectMode()
 
         // keyBuffer는 activateServer에서만 정리 (focus-steal 증거 보존)
 
@@ -670,6 +681,10 @@ class OngeulInputController: IMKInputController {
         guard let event = event,
               let client = sender as? (any IMKTextInput) else {
             return false
+        }
+
+        if event.type == .keyDown {
+            bumpSelectModeIdle()
         }
 
         loadLayoutIfNeeded()
@@ -753,9 +768,9 @@ class OngeulInputController: IMKInputController {
         refreshLockCache()
         applyEffect(effect, to: client)
 
-        // Lock 토글은 modeChanged=false이므로 아이콘 별도 동기화
+        // Lock 토글은 modeChanged=false이므로 아이콘 별도 동기화 (디바운스)
         let modeId = InputModeID.from(coordinator.mode)
-        client.selectMode(modeId)
+        scheduleSelectMode(modeId)
     }
 
     /// KeyEventTap에서 호출: 현재 앱이 English Lock 상태인지 반환.
@@ -775,6 +790,9 @@ class OngeulInputController: IMKInputController {
             super.setValue(value, forTag: tag, client: sender)
             return
         }
+
+        // 외부에서 모드를 강제했으므로 보류된 selectMode는 stale.
+        cancelSelectMode()
 
         let targetMode: InputMode = (modeId == InputModeID.english) ? .english : .korean
 
@@ -956,9 +974,10 @@ class OngeulInputController: IMKInputController {
             os_log("mode → %{public}@", log: log, type: .default,
                    coordinator.mode == .korean ? "korean" : "english")
 
-            // 메뉴바 아이콘 동기화
+            // 메뉴바 아이콘 동기화 — 디바운스: 사용자 입력이 idle 상태가 될 때 호출.
+            // 즉시 호출하면 macOS IMK가 ~100–350ms keystroke dispatch를 stall한다.
             let modeId = InputModeID.from(coordinator.mode)
-            client.selectMode(modeId)
+            scheduleSelectMode(modeId)
         }
         switch effect.lockOverlay {
         case .show(let locked):
@@ -970,6 +989,50 @@ class OngeulInputController: IMKInputController {
         case nil:
             break
         }
+    }
+
+    // MARK: - Private: SelectMode Debounce
+
+    /// 모드 변경 시 호출. 사용자 입력이 idle 상태가 될 때까지 selectMode를 지연한다.
+    /// 같은 modeId로 연속 호출되면 타이머만 재시작; 다른 modeId면 보류 대상이 갱신된다.
+    private func scheduleSelectMode(_ modeId: String) {
+        pendingSelectModeId = modeId
+        pendingSelectModeTask?.cancel()
+        let task = DispatchWorkItem { [weak self] in
+            self?.fireSelectMode()
+        }
+        pendingSelectModeTask = task
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + Self.selectModeIdleInterval, execute: task)
+    }
+
+    /// keyDown 진입 시 호출. 보류 중일 때만 타이머 재시작 (idle 카운트 리셋).
+    private func bumpSelectModeIdle() {
+        guard let modeId = pendingSelectModeId else { return }
+        scheduleSelectMode(modeId)
+    }
+
+    /// 보류된 selectMode를 즉시 호출 (deactivateServer 등 stall이 더 이상 의미 없을 때).
+    private func flushSelectMode() {
+        guard pendingSelectModeTask != nil else { return }
+        pendingSelectModeTask?.cancel()
+        fireSelectMode()
+    }
+
+    /// 보류된 selectMode를 폐기 (외부 모드 변경, 새 client attach 등 stale 상황).
+    private func cancelSelectMode() {
+        pendingSelectModeTask?.cancel()
+        pendingSelectModeTask = nil
+        pendingSelectModeId = nil
+    }
+
+    /// 타이머 만료 또는 flush 시 호출. client가 없으면 조용히 폐기.
+    private func fireSelectMode() {
+        let modeId = pendingSelectModeId
+        pendingSelectModeTask = nil
+        pendingSelectModeId = nil
+        guard let modeId, let client: any IMKTextInput = self.client() else { return }
+        client.selectMode(modeId)
     }
 
     // MARK: - Private: Layout Loading
@@ -1029,6 +1092,8 @@ extension OngeulInputController: FocusStealDelegate {
     }
 
     func focusStealSyncIconKorean() {
+        // focus-steal은 한글 모드를 강제하므로 보류된 selectMode는 stale.
+        cancelSelectMode()
         self.client()?.selectMode(InputModeID.korean)
     }
 


### PR DESCRIPTION
## Summary

한↔영 토글 직후 첫 1–4 keystroke가 100–350ms 지연됐다가 한꺼번에 dispatch되는 문제 수정. 영문/한글이 별도 input source로 등록되어 토글마다 `client.selectMode()`가 호출되는데, **selectMode 직후 macOS IMK가 keystroke dispatch를 일시 stall**한다. selectMode 호출을 keystroke idle **0.6s** 디바운스하여 우회.

System Settings 텍스트 대치 입력창처럼 IME activate/메뉴 갱신이 반복되는 화면에서는 매 activate마다 selectMode → 연속 stall로 단축키 한/영 전환이 아예 안 먹는 것처럼 보였다 (이슈 #7).

## Cause

토글 직후 CGEventTap→IMK dispatch gap 측정: 모드 안정 시 ~5–10ms, 토글 직후 첫 키 ~313–354ms (이후 키 순차 감소, 4–5번째부터 정상화). 한→영/영→한 대칭. focus-steal correction과 무관한 별개 원인.

## Solution

selectMode를 마지막 keyDown으로부터 `selectModeIdleInterval`(**0.6s**) 동안 추가 입력이 없을 때만 호출하도록 디바운스.

| 메서드 | 호출 시점 |
|---|---|
| `scheduleSelectMode(_:)` | `applyEffect`(modeChanged) · `performEnglishLockToggleFromTap`(English Lock) — 보류 시작 |
| `bumpSelectModeIdle()` | `handle` keyDown 진입마다 타이머 리셋 |
| `fireSelectMode()` | idle 만료 시 실제 `client.selectMode()` 실행 |
| `flushSelectMode()` | `deactivateServer` — 입력 끝, 즉시 호출 |
| `cancelSelectMode()` | `activateServer` · `setValue` · focus-steal 아이콘 동기화 — stale 폐기 |

타이핑 중에는 selectMode 미발동(stall 없음), 입력이 멈춘 뒤에야 메뉴바 아이콘 동기화.

**Trade-off:** 메뉴바 한/영 아이콘 동기화가 타이핑 멈춘 후 최대 0.6s 지연. (0.3s는 자연스러운 타이핑 멈춤에 만료되어 stall 재노출 → 0.6s 상향, 1.0s는 과해 절충.)

## Test plan

- [ ] 한↔영 토글 직후 첫 키가 stall 없이 즉시 표시 (양방향)
- [ ] 입력 멈춤 0.6s 후 메뉴바 아이콘 정상 동기화
- [ ] 앱 전환 시 보류된 selectMode flush, focus-steal 시 stale 폐기
- [ ] English Lock 토글에도 디바운스 적용
- [ ] FocusStealCorrector regression suite 통과

## Notes

- Base: #4 (`fix/focus-steal-corrector`) — 같은 파일 후속 변경.
- Fixes #7 — 텍스트 대치 입력창 한/영 전환 불가. VM(Sequoia 15.7.3) 재현으로 본 브랜치에서 해소 확인.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
