### PR TITLE
fix(capslock): strip stale maskAlphaShift on keyDown when toggleKey=.capsLock

### DIFF
--- a/OngeulApp/Sources/KeyEventTap.swift
+++ b/OngeulApp/Sources/KeyEventTap.swift
@@ -65,14 +65,21 @@ class KeyEventTap {
                 }
 
                 let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
-                let flags = event.flags
+                var flags = event.flags
 
                 // keyDown → modifier tap 판정 취소 + 마지막 키 기록
                 if type == .keyDown {
-                    // CapsLock 방어: 어떤 이유로든 CapsLock이 켜져 있으면 즉시 OFF
+                    // CapsLock 방어: 어떤 이유로든 CapsLock이 켜져 있으면 즉시 OFF.
+                    // forceOff()의 IOKit 왕복 지연 동안 keyDown에 남는 stale
+                    // maskAlphaShift를 이벤트에서 직접 제거하여 영문 통과 경로의
+                    // 대문자 누수(이슈 #10)를 차단한다. 탭이 IME·앱보다 앞단이므로
+                    // IMK 경로와 영문 직통 경로가 한 곳에서 모두 보정된다.
+                    // 이후 keyboardGetUnicodeString도 보정된 flags를 사용한다.
                     if KeyEventTap.toggleKey == .capsLock
                         && flags.contains(.maskAlphaShift) {
                         CapsLockSync.forceOff()
+                        flags.subtract(.maskAlphaShift)
+                        event.flags = flags
                     }
 
                     KeyEventTap.toggleDetector.cancelOnKeyDown()


### PR DESCRIPTION
## Problem

When CapsLock is configured as the Korean/English toggle key, the IOKit
alpha-lock state can briefly remain ON between the physical CapsLock press
and `CapsLockSync.forceOff()` taking effect (an IOKit round-trip via
`IOHIDSetModifierLockState`). A `keyDown` arriving in that race window
carries `.maskAlphaShift`.

In **English passthrough mode** the event is delivered to the focused app
as-is, so the first English character after a Korean→English toggle is
uppercased, then later keys auto-correct — exactly the symptom reported
in #10. Korean mode is unaffected because `KeyLabelConverter` already
neutralizes CapsLock there.

## Fix

Strip `.maskAlphaShift` directly from the event in the `CGEventTap`
callback right after `forceOff()`. The tap runs at
`.cgSessionEventTap`/`.headInsertEventTap`, i.e. **before** HIToolbox /
IME / app, so both the IMK path and the English passthrough path see the
corrected flags — independent of `forceOff()`'s IOKit propagation latency.

`event.keyboardGetUnicodeString()` runs later in the same callback and
also picks up the stripped flags, keeping the focus-steal recorded
character consistent with what the app receives.

Change is at `OngeulApp/Sources/KeyEventTap.swift:68` (`let` → `var`
flags) and `:72-83` (the strip).

## Scope

- Only active when `toggleKey == .capsLock` **and** `.maskAlphaShift` is
  set on a `keyDown`. No effect for other toggle keys, no effect when the
  flag is already clear.
- Does not consume any event; only mutates flags on the keyDown that
  would otherwise leak.
- The `flagsChanged` CapsLock branch (`:165-184`) is **intentionally left
  as passthrough**. Consuming it would hide `forceOff()`'s OFF correction
  from downstream state tracking. The keyDown strip is the canonical
  defense; flagsChanged passthrough keeps WindowServer/app state
  self-correcting.

## Not a definitive fix for #10

This is **defensive hardening**, not a closure of #10. The reported case
is environment-dependent — the maintainer cannot reproduce on a clean
setup — and likely involves either coexisting low-level keyboard monitors
(e.g. SokIM, which also drives the global CapsLock state at the HID
layer) or macOS 26 Tahoe-specific timing. Root-cause investigation
continues separately, including a planned HID-based CapsLock handler that
would also support long-press for conventional CapsLock uppercase. When
that lands, this strip will need to be gated on a future
`realCapsLockActive` flag so long-press can actually produce uppercase.

## Verification

- `swiftc -typecheck` of all sources (Generated + `OngeulApp/Sources/*.swift`)
  passes with no warnings.
- Runtime verification on a real CapsLock-as-toggle setup is recommended
  before release; included in follow-up testing on Sequoia and Tahoe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
