### PR TITLE
feat(capslock): Phase 1 — doc 30 SET semantics (LED ON = Korean)

### DIFF
--- a/OngeulApp/Resources/en.lproj/Localizable.strings
+++ b/OngeulApp/Resources/en.lproj/Localizable.strings
@@ -20,7 +20,7 @@
 "prefs.toggleKey.rightShift" = "Right Shift (tap)";
 "prefs.toggleKey.shiftSpace" = "Shift + Space";
 "prefs.toggleKey.capsLock" = "CapsLock";
-"prefs.capsLockDelay" = "Disable CapsLock delay in System Settings > Keyboard.";
+"prefs.capsLockDelay" = "macOS has no UI to disable CapsLock delay; hidutil is required — see documentation.";
 
 /* Escape → English */
 "prefs.escapeToEnglish" = "Switch to English on ESC / Ctrl+[ (Vim mode)";

--- a/OngeulApp/Resources/ko.lproj/Localizable.strings
+++ b/OngeulApp/Resources/ko.lproj/Localizable.strings
@@ -20,7 +20,7 @@
 "prefs.toggleKey.rightShift" = "오른쪽 Shift (단독)";
 "prefs.toggleKey.shiftSpace" = "Shift + Space";
 "prefs.toggleKey.capsLock" = "CapsLock";
-"prefs.capsLockDelay" = "시스템 설정 > 키보드에서 CapsLock 지연을 비활성화하세요.";
+"prefs.capsLockDelay" = "macOS 자체 UI로는 CapsLock 지연을 끄지 못합니다. 터미널에서 hidutil 명령 필요 — 자세한 안내는 문서 참고.";
 
 /* Escape → English */
 "prefs.escapeToEnglish" = "ESC / Ctrl+[ 키로 영문 전환 (Vim 모드)";

--- a/OngeulApp/Sources/CapsLockSync.swift
+++ b/OngeulApp/Sources/CapsLockSync.swift
@@ -9,17 +9,69 @@ func IOHIDSetModifierLockState(_ handle: io_connect_t, _ selector: Int32, _ stat
 
 private let kIOHIDCapsLockState: Int32 = 1
 
+/// CapsLock LED/상태를 IOHIDSystem 레벨에서 SET하는 래퍼.
+///
+/// [doc 30](../../../design/30-capslock-mode-sync.md)의 양방향 SET 의미론을 구현한다:
+/// - 모드 변경 → `setState(mode == .korean)` → LED 동기화
+/// - 사용자 CapsLock 누름 → `flagsChanged` 수신 → mode SET (호출자가 처리)
+///
+/// `IOHIDSetModifierLockState` 호출은 후속 `flagsChanged` echo를 발생시킬 수 있으므로,
+/// 그 echo를 사용자 입력으로 오해하지 않도록 `expectedState` 가드를 둔다.
 enum CapsLockSync {
-    /// CapsLock LED를 항상 OFF로 강제.
-    static func forceOff() {
-        os_log("forceOff", log: log, type: .debug)
+    /// 소프트웨어가 설정한 예상 상태. `nil`이면 예상 대기 중 아님.
+    private static var expectedState: Bool? = nil
+    /// `expectedState` 설정 시각 (타임아웃 판정용).
+    private static var expectedStateTimestamp: CFAbsoluteTime = 0
+    /// `expectedState` 타임아웃 (100ms).
+    /// `IOHIDSetModifierLockState` 호출 후 echo가 발생하지 않는 경우 `expectedState`가
+    /// 영구히 남아 다음 사용자 CapsLock 입력을 한 번 무시하는 것을 방지한다.
+    /// 사용자가 100ms 이내에 CapsLock을 누르는 것은 물리적으로 불가능하므로 안전.
+    private static let expectedStateTimeout: CFAbsoluteTime = 0.1
+
+    /// `IOHIDSetModifierLockState`로 CapsLock LED/상태 설정.
+    /// 호출 후 발생하는 `flagsChanged` echo는 `shouldHandle()`에서 필터링된다.
+    static func setState(_ enabled: Bool) {
+        os_log("setState: %{public}d", log: log, type: .debug, enabled)
+        expectedState = enabled
+        expectedStateTimestamp = CFAbsoluteTimeGetCurrent()
         let service = IOServiceGetMatchingService(
             kIOMainPortDefault,
             IOServiceMatching("IOHIDSystem")
         )
         if service != IO_OBJECT_NULL {
-            _ = IOHIDSetModifierLockState(service, kIOHIDCapsLockState, false)
+            _ = IOHIDSetModifierLockState(service, kIOHIDCapsLockState, enabled)
             IOObjectRelease(service)
         }
+    }
+
+    /// `flagsChanged`에서 호출. 소프트웨어가 유발한 echo면 `false`(무시), 사용자 입력이면 `true`(처리).
+    ///
+    /// 타이밍 의존적인 `isSyncing` 플래그 대신 *예상 상태 비교* 방식을 쓴다:
+    /// 소프트웨어가 설정한 상태와 도착한 이벤트가 일치하면 echo로 간주.
+    /// 100ms 타임아웃은 echo가 발생하지 않는 경우의 안전망.
+    static func shouldHandle(capsLockOn: Bool) -> Bool {
+        guard let expected = expectedState else { return true }
+        if CFAbsoluteTimeGetCurrent() - expectedStateTimestamp > expectedStateTimeout {
+            expectedState = nil
+            return true  // 타임아웃 → 사용자 입력으로 간주
+        }
+        if expected == capsLockOn {
+            expectedState = nil  // 예상된 echo → 무시
+            return false
+        }
+        expectedState = nil
+        return true  // 예상과 다름 → 사용자 입력
+    }
+
+    /// 설정 변경 시 LED OFF + 상태 초기화.
+    /// `toggleKey`를 `.capsLock`에서 다른 키로 변경할 때 호출.
+    static func reset() {
+        setState(false)
+    }
+
+    /// 하위 호환: 기존 호출자(설정 패널·KeyEventTap keyDown 방어 등)가 사용.
+    /// 기능적으로 `setState(false)`와 동일.
+    static func forceOff() {
+        setState(false)
     }
 }

--- a/OngeulApp/Sources/InputStateCoordinator.swift
+++ b/OngeulApp/Sources/InputStateCoordinator.swift
@@ -31,19 +31,32 @@ final class InputStateCoordinator: FocusStealModeController {
     func backspace() -> ProcessResult { engine.backspace() }
     func flush() -> ProcessResult { engine.flush() }
 
-    // MARK: - Private: 모드 변경 + KeyEventTap 동기화
+    // MARK: - Private: 모드 변경 + KeyEventTap / CapsLock LED 동기화
 
-    /// 모드 변경 + KeyEventTap 동기화.
-    /// KeyEventTap은 CGEvent 레벨에서 현재 모드를 참조하므로(Control+[ 필터링, keyBuffer 기록),
-    /// 모든 모드 변경 시 반드시 동기화해야 한다.
-    private func setMode(_ mode: InputMode) {
+    /// 모드 변경 + KeyEventTap 동기화 + CapsLock LED 동기화(doc 30).
+    ///
+    /// - KeyEventTap은 CGEvent 레벨에서 현재 모드를 참조하므로(Control+[ 필터링, keyBuffer 기록),
+    ///   모든 모드 변경 시 반드시 동기화해야 한다.
+    /// - `toggleKey == .capsLock`일 때 LED를 모드에 동기화한다(LED ON = 한글).
+    ///   `syncCapsLock: false`는 CapsLock 누름 자체가 모드 변경을 일으킨 경로에서 사용:
+    ///   하드웨어가 이미 LED를 변경했으므로 재설정은 echo만 만들 뿐 (shouldHandle이 걸러내긴 하지만 불필요).
+    private func setMode(_ mode: InputMode, syncCapsLock: Bool = true) {
         engine.setMode(mode: mode)
         KeyEventTap.currentInputMode = mode
+        if syncCapsLock && KeyEventTap.toggleKey == .capsLock {
+            CapsLockSync.setState(mode == .korean)
+        }
     }
 
+    /// `engine.toggleMode()` 직접 호출 경로(다른 전환 키, IMK fallback 등).
+    /// setMode를 거치지 않으므로 KeyEventTap·CapsLock LED 동기화를 직접 수행.
     private func toggleEngineMode() -> ProcessResult {
         let result = engine.toggleMode()
-        KeyEventTap.currentInputMode = engine.getMode()
+        let mode = engine.getMode()
+        KeyEventTap.currentInputMode = mode
+        if KeyEventTap.toggleKey == .capsLock {
+            CapsLockSync.setState(mode == .korean)
+        }
         return result
     }
 
@@ -119,6 +132,24 @@ final class InputStateCoordinator: FocusStealModeController {
         if let bundleId { perAppStore.saveMode(newMode, for: bundleId) }
 
         return StateEffect(processResult: result, modeChanged: true)
+    }
+
+    /// CapsLock 누름에 의한 모드 SET (doc 30 SET 의미론).
+    ///
+    /// 사용자가 CapsLock을 누른 시점에는 macOS 하드웨어가 이미 alpha-lock 상태를 토글했으므로,
+    /// 그 결과 상태를 입력 모드에 그대로 반영(LED ON=한글, LED OFF=영문)한다.
+    /// `syncCapsLock: false`로 호출 — 하드웨어가 이미 변경한 LED를 우리가 다시 set 하는
+    /// 불필요한 echo를 피한다 (`CapsLockSync.shouldHandle()`이 막아주긴 하지만 호출 자체 회피).
+    ///
+    /// Lock 상태면 nil 반환 (구조적 가드).
+    func setModeFromCapsLockPress(korean: Bool, for bundleId: String?) -> StateEffect? {
+        if isLocked(bundleId) { return nil }
+        let newMode: InputMode = korean ? .korean : .english
+        // 한글 → 영문 전환 시 조합 중인 한글 flush
+        let flushResult = (engine.getMode() == .korean && newMode != .korean) ? engine.flush() : nil
+        setMode(newMode, syncCapsLock: false)
+        if let bundleId { perAppStore.saveMode(newMode, for: bundleId) }
+        return StateEffect(processResult: flushResult, modeChanged: true)
     }
 
     /// English Lock 토글

--- a/OngeulApp/Sources/KeyEventTap.swift
+++ b/OngeulApp/Sources/KeyEventTap.swift
@@ -69,14 +69,20 @@ class KeyEventTap {
 
                 // keyDown → modifier tap 판정 취소 + 마지막 키 기록
                 if type == .keyDown {
-                    // CapsLock 방어: 어떤 이유로든 CapsLock이 켜져 있으면 즉시 OFF.
-                    // forceOff()의 IOKit 왕복 지연 동안 keyDown에 남는 stale
-                    // maskAlphaShift를 이벤트에서 직접 제거하여 영문 통과 경로의
-                    // 대문자 누수(이슈 #10)를 차단한다. 탭이 IME·앱보다 앞단이므로
-                    // IMK 경로와 영문 직통 경로가 한 곳에서 모두 보정된다.
-                    // 이후 keyboardGetUnicodeString도 보정된 flags를 사용한다.
+                    // CapsLock 방어 (영문 모드 한정): 영문 통과 경로에서 stale
+                    // maskAlphaShift가 남으면 대문자가 누수된다(이슈 #10). forceOff()의
+                    // IOKit 왕복 지연 동안 keyDown에 남는 비트를 이벤트에서 직접 제거하고
+                    // LED도 OFF로 강제한다. 탭이 IME·앱보다 앞단이므로 IMK 경로와 영문
+                    // 직통 경로가 한 곳에서 모두 보정된다. 이후 keyboardGetUnicodeString도
+                    // 보정된 flags를 사용한다.
+                    //
+                    // 한글 모드에서는 strip하지 않는다: doc 30의 "LED ON = 한글" 의미론상
+                    // alpha-lock이 켜져 있는 것이 정상(= LED 인디케이터)이고, 자모는 keycode
+                    // 기반이라 대문자 누수가 없다. 여기서 끄면 한글 진입 후 첫 키 입력에
+                    // LED가 꺼져 인디케이터가 무력화된다.
                     if KeyEventTap.toggleKey == .capsLock
-                        && flags.contains(.maskAlphaShift) {
+                        && flags.contains(.maskAlphaShift)
+                        && KeyEventTap.currentInputMode == .english {
                         CapsLockSync.forceOff()
                         flags.subtract(.maskAlphaShift)
                         event.flags = flags

--- a/OngeulApp/Sources/KeyEventTap.swift
+++ b/OngeulApp/Sources/KeyEventTap.swift
@@ -172,18 +172,21 @@ class KeyEventTap {
                 if type == .flagsChanged && keyCode == Int64(KeyCode.capsLock)
                     && KeyEventTap.toggleKey == .capsLock {
                     let capsLockOn = flags.contains(.maskAlphaShift)
-                    os_log("capsLock flagsChanged: capsLockOn=%{public}d", log: log, type: .debug, capsLockOn)
-                    // capsLockOn=true (OFF→ON press)만 처리. forceOff()가 하드웨어를 항상 OFF로
-                    // 유지하므로 모든 실제 press는 capsLockOn=true. false는 echo 또는 release.
-                    if capsLockOn {
-                        CapsLockSync.forceOff()
+                    // doc 30 SET 의미론: LED ON=한글, LED OFF=영문. 하드웨어가 이미 상태를
+                    // 토글했으므로 SET을 그대로 받아들이고 모드를 그에 맞춘다.
+                    // CapsLockSync.shouldHandle()이 setState() echo를 필터링한다.
+                    if CapsLockSync.shouldHandle(capsLockOn: capsLockOn) {
+                        os_log("capsLock flagsChanged: capsLockOn=%{public}d (user)",
+                               log: log, type: .debug, capsLockOn)
                         if let controller = KeyEventTap.activeController,
                            !controller.isCurrentAppLocked() {
                             // 동기 호출: CapsLock은 key press 시점에 발생하므로
                             // async를 사용하면 다음 keyDown이 모드 전환 전에 도착할 수 있다.
-                            controller.performToggleFromTap()
-                            os_log("capsLock: toggled", log: log, type: .debug)
+                            controller.performCapsLockModeSet(korean: capsLockOn)
                         }
+                    } else {
+                        os_log("capsLock flagsChanged: capsLockOn=%{public}d (echo, filtered)",
+                               log: log, type: .debug, capsLockOn)
                     }
                     return Unmanaged.passUnretained(event)  // 이벤트 통과 — 앱에 정상 전달
                 }

--- a/OngeulApp/Sources/KeyEventTap.swift
+++ b/OngeulApp/Sources/KeyEventTap.swift
@@ -65,14 +65,21 @@ class KeyEventTap {
                 }
 
                 let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
-                let flags = event.flags
+                var flags = event.flags
 
                 // keyDown → modifier tap 판정 취소 + 마지막 키 기록
                 if type == .keyDown {
-                    // CapsLock 방어: 어떤 이유로든 CapsLock이 켜져 있으면 즉시 OFF
+                    // CapsLock 방어: 어떤 이유로든 CapsLock이 켜져 있으면 즉시 OFF.
+                    // forceOff()의 IOKit 왕복 지연 동안 keyDown에 남는 stale
+                    // maskAlphaShift를 이벤트에서 직접 제거하여 영문 통과 경로의
+                    // 대문자 누수(이슈 #10)를 차단한다. 탭이 IME·앱보다 앞단이므로
+                    // IMK 경로와 영문 직통 경로가 한 곳에서 모두 보정된다.
+                    // 이후 keyboardGetUnicodeString도 보정된 flags를 사용한다.
                     if KeyEventTap.toggleKey == .capsLock
                         && flags.contains(.maskAlphaShift) {
                         CapsLockSync.forceOff()
+                        flags.subtract(.maskAlphaShift)
+                        event.flags = flags
                     }
 
                     KeyEventTap.toggleDetector.cancelOnKeyDown()

--- a/OngeulApp/Sources/OngeulInputController.swift
+++ b/OngeulApp/Sources/OngeulInputController.swift
@@ -707,14 +707,15 @@ class OngeulInputController: IMKInputController {
         // (접근성 미허용 시에만 이 경로로 폴백)
         if KeyEventTap.shared.isInstalled { return false }
 
-        // CapsLock 전환 (CGEventTap 미설치 폴백)
+        // CapsLock 전환 (CGEventTap 미설치 폴백, doc 30 SET 의미론)
         if Self.toggleKey == .capsLock && event.keyCode == KeyCode.capsLock {
-            // capsLockOn=true (press)만 처리. release/echo는 무시.
-            guard event.modifierFlags.contains(.capsLock) else { return false }
-            CapsLockSync.forceOff()  // LED OFF 유지 (locked 상태와 무관)
+            let capsLockOn = event.modifierFlags.contains(.capsLock)
+            // CapsLockSync.setState() echo 필터링
+            guard CapsLockSync.shouldHandle(capsLockOn: capsLockOn) else { return false }
             guard !isCurrentAppLocked() else { return false }
-            guard let effect = coordinator.toggleMode(for: currentBundleId)
-            else { return false }
+            guard let effect = coordinator.setModeFromCapsLockPress(
+                korean: capsLockOn, for: currentBundleId
+            ) else { return false }
             applyEffect(effect, to: client)
             return false  // flagsChanged는 소비하지 않음
         }
@@ -746,6 +747,18 @@ class OngeulInputController: IMKInputController {
     func performToggleFromTap() {
         guard let client: any IMKTextInput = self.client(),
               let effect = coordinator.toggleMode(for: currentBundleId)
+        else { return }
+        applyEffect(effect, to: client)
+    }
+
+    /// KeyEventTap의 CapsLock flagsChanged 분기에서 호출 (doc 30 SET 의미론).
+    /// `korean: true` ⇒ 한글 모드 SET, `false` ⇒ 영문 모드 SET.
+    /// 사용자가 CapsLock을 누른 결과 LED 상태를 입력 모드에 반영하는 단방향 SET.
+    func performCapsLockModeSet(korean: Bool) {
+        guard let client: any IMKTextInput = self.client(),
+              let effect = coordinator.setModeFromCapsLockPress(
+                  korean: korean, for: currentBundleId
+              )
         else { return }
         applyEffect(effect, to: client)
     }

--- a/design/32-hid-capslock-press-duration.md
+++ b/design/32-hid-capslock-press-duration.md
@@ -1,0 +1,533 @@
+# 32. HID 기반 CapsLock 입력 처리 (짧게 / 길게 분리)
+
+> **상태**: 설계 v2 — Phase 1.5 스파이크 결과 대기
+
+## Context
+
+[30. CapsLock LED 기반 한영 모드 동기화](30-capslock-mode-sync.md)는 `IOHIDSetModifierLockState`로 LED와 입력 모드를 양방향 SET하는 의미론을 정의했다(2차 검토 완료, 구현 대기). 본 문서는 그 기반 위에서 **macOS 플랫폼 표준 동작과의 parity** — *"CapsLock 짧은 탭 = 입력 소스 전환, 길게 누름 = 본연 대문자 잠금"* — 을 Ongeul에 도입하는 설계를 다룬다.
+
+이 짧게/길게 분리는 fringe 기능이 *아니다*. macOS 입력 소스 설정의 *"Use Caps Lock to switch to and from U.S."* 옵션 본문은 Apple 자체 UI 문구로 다음을 명시한다:
+
+> **"Press and hold to enable typing in all uppercase."**
+
+한국어/일본어 macOS 사용자는 Sierra(2016) 이래 이 패턴에 학습돼 있고, SokIM·구름·Apple 기본 Korean IM이 모두 이 규약을 따른다. **현재 Ongeul의 "길게 = 미지원" 입장이 플랫폼 표준에서 벗어난 쪽**이며, 본 doc은 그 격차를 메운다.
+
+단일 CGEvent 레이어로는 **물리 키의 press 지속시간을 측정할 수 없으므로** (`flagsChanged`는 잠금-상태 토글 통지만 전달), HID(IOHIDManager) 레이어를 추가 도입한다.
+
+### 비-목표
+
+- 모든 키 입력을 HID로 받는 SokIM/Karabiner 스타일 IME로의 전환 — 아키텍처 손상이 크고 충돌 위험 증가.
+- 본연 CapsLock 대문자를 Ongeul 자체 엔진으로 합성 — `(B)` 기능을 위해 입력 전체 경로를 바꾸는 것은 비례성 어긋남. (단, [§ 스파이크](#스파이크-계획) 결과 B면 영문 통과 경로에 한정 합성을 *후속 추가*하는 폴백은 열어둠.)
+
+## 가장 큰 단일 가정 — 스파이크 우선
+
+본 설계 전체는 **하나의 미검증 가정** 위에 서 있다:
+
+> *"`IOHIDSetModifierLockState(handle, kIOHIDCapsLockState, true)` 호출 후, 후속 keyDown들이 alpha-shift 적용된(대문자) 문자로 macOS 텍스트 입력 경로를 통해 앱에 전달된다."*
+
+근거와 우려:
+
+- [doc 30](30-capslock-mode-sync.md)의 실측표(2026-03-21, macOS 26.3.0)에서 `IOHIDSetModifierLockState`는 **상태 변경 + LED 변경** 모두 성공으로 기록됨. 단 *"alpha-lock이 켜진 동안 실제 키 입력이 대문자로 들어가는지"*는 직접 검증 항목으로 명시되지 않았다.
+- 반증 정황: [SokIM](https://github.com/kiding/SokIM)은 본연 CapsLock 활성화 의도로 `setKeyboardCapsLock(enabled: true)`를 호출하지만, 본체([Helpers.swift](https://github.com/kiding/SokIM/blob/main/SokIM/Helpers.swift))는 `enabled` 값과 무관하게 `IOHIDSetModifierLockState(..., false)` + `HIS_XPC_SetCapsLockModifierState(false)`를 호출한다. 시스템 상태를 ON으로 두지 못해 LED만 ON하고 자체 `QwertyEngine`으로 대문자를 합성하는 방식. OS가 외부 상태 변경을 되돌리는 것에 대비해 false-set을 `0, 20, …, 180ms` 11회 반복 예약하며 주석에 *"HIS_XPC: Sonoma 이후 커서 밑에 생기는 '버블'/HUD/Indicator/Accessory 방지"* 라 명시.
+- `IOHIDSetModifierLockState(true)`가 단순·신뢰성 있게 동작한다면 SokIM이 그런 우회를 할 이유가 없다.
+
+→ **결론**: 본 doc의 구현 검증 전 *반드시* 다음 스파이크가 선행되어야 한다 (상세는 [§ 스파이크 계획](#스파이크-계획)).
+
+선택지 매트릭스 (스파이크 결과에 따른 분기):
+
+| 결과 | 옵션 | 함의 |
+|---|---|---|
+| `IOHIDSetModifierLockState(true)` → 앱이 대문자 수신 | **A** | 본 doc 그대로 진행 |
+| 상태/LED는 켜지나 앱은 소문자 수신 | **B** | 영문 통과 경로에 *uppercase override* 합성 추가. HID는 여전히 press 지속시간 감지에만 사용 |
+| 상태/LED 자체가 외부 stomp에 의해 즉시 되돌려짐 | **C** | 이 doc 보류. (B) 기능 미지원 유지 — HID는 짧은 탭 신뢰성·#10 race 차단 용도로만 한정 채택할지 별도 판단 |
+
+본 문서 이하 내용은 결과 **A** 가정. **B**가 되면 § 기존 코드 통합 절의 일부만 교체(영문 통과 경로에 대문자 합성). **C**면 doc 폐기.
+
+## 목표
+
+| | |
+|---|---|
+| (1) | CapsLock **짧은 탭** → 한/영 토글 (현행 유지, 무지연) |
+| (2) | CapsLock **길게 누름(≥800ms)** → 본연 CapsLock 대문자 ON, 한/영 토글 억제 (**macOS native parity**) |
+| (3) | 본연 CapsLock ON 상태에서 **짧은 탭** → CapsLock OFF만 (한/영 토글 없음) |
+| (4) | #10 race를 단일 권위 드라이버(HID)로 좁힘 |
+| (5) | 옵트인 — `toggleKey != .capsLock` 사용자에겐 영향·권한 부담 없음 |
+
+## 왜 CGEvent로는 부족한가 (요지)
+
+CapsLock은 macOS 표준 이벤트 모델에서 **잠금 모디파이어**다. CGEventTap·`NSEvent.flagsChanged` 레이어는 *alpha-lock 상태가 토글됐다는 통지*만 전달한다. 물리 키의 down/up 분리 이벤트와 hardware timestamp가 모두 노출되지 않으므로, **press 지속시간을 측정할 방법이 없다**.
+
+반면 HID(USB HID Usage Tables) 레이어에서 CapsLock은 Keyboard/Keypad usage `0x39`이고, IOHIDManager의 input value 콜백은 raw make(1)/break(0)을 **`IOHIDValueGetTimeStamp`로 얻는 하드웨어 타임스탬프와 함께** 보고한다. SokIM이 본 메커니즘으로 800ms 길게-누름을 구현하고 있는 것이 작동 증명.
+
+## HID 도입의 부수 효과 (사용자 안내 단순화)
+
+본 도입의 추가 가치 — HID 레이어는 **macOS의 시스템 Caps Lock 지연(약 100–250ms)보다 아래** 에 있어, 사용자가 `hidutil property --set '{"CapsLockDelayOverride":0}'` 같은 명령으로 시스템 지연을 비활성화하지 *않아도* 모든 물리 press를 raw로 받는다(SokIM이 사용자 지연 설정과 무관하게 동작하는 것이 증거).
+
+기존 [docs/.../capslock.md](../docs/src/user/features/capslock.md) 는 *"시스템 설정에서 CapsLock 지연을 비활성화"* 라고 안내하지만:
+
+1. **그런 시스템 UI는 존재하지 않는다** (Sequoia/Tahoe 모두 없음).
+2. 유일한 합법 경로는 `hidutil` CLI이며 재부팅 시 초기화 (영구화는 LaunchAgent 필요).
+3. **HID 활성 상태에서는 이 안내 자체가 불필요해진다.**
+
+→ Phase 3에서 capslock.md를 갱신하여, *HID 모드에선 권한 부여만 하면 끝 / CGEventTap 폴백 모드에서만 `hidutil` 안내* 로 분리. (스파이크 측정 항목 #6에서 *"HID 콜백이 시스템 Caps Lock 지연과 무관하게 도착하는지"* 1차 검증.)
+
+## Doc 30과의 관계
+
+doc 32는 doc 30을 *대체하지 않는다*. 분업:
+
+| 책임 | 모듈 | 출처 |
+|---|---|---|
+| LED/상태 양방향 SET, 재진입 가드(`expectedState` + 100ms 타임아웃) | `CapsLockSync` | doc 30 |
+| 모드 ↔ LED 동기화 (모든 모드 변경 경로) | `InputStateCoordinator.setMode(_, syncCapsLock:)` | doc 30 |
+| `TICapsLockLanguageSwitchCapable` 제거 | Info.plist | doc 30 (현재 코드 확인: 이미 없음) |
+| **CapsLock press 짧게/길게 분리** | `CapsLockHIDMonitor` (신규) | **doc 32** |
+| **본연 CapsLock 활성화 (`setState(true)`)** | `CapsLockSync` API는 doc 30이 정의, doc 32는 호출자 | **doc 32** |
+| **CGEventTap CapsLock 분기의 게이팅(HID 활성 시 우회)** | `KeyEventTap` 수정 | **doc 32** |
+| TCC UX 시트(권한 안내·딥링크) | `OngeulInputController` 설정 패널 | **doc 32** |
+
+doc 30이 정의한 SET 의미론(*"LED ON = 한글"*)은 **짧은 탭 분기에서만 적용**되고, 길게-누름은 SET 의미론 외부의 별도 분기(=본연 CapsLock)로 다룬다.
+
+## 옵트인 게이팅
+
+HID 모니터는 다음 조건에서만 기동·유지:
+
+```
+toggleKey == .capsLock  AND  사용자가 입력 모니터링 권한 부여
+```
+
+전환 키가 다른 값이면 HID 모니터는 즉시 정지·해제. 다른 전환 키 사용자는 본 doc의 모든 코드 경로·권한 요구에 노출되지 않는다.
+
+### 매칭 범위 — CapsLock만
+
+```swift
+IOHIDManagerSetDeviceMatching(hid, [
+    kIOHIDDeviceUsagePageKey: kHIDPage_GenericDesktop,
+    kIOHIDDeviceUsageKey: kHIDUsage_GD_Keyboard
+] as CFDictionary)
+
+IOHIDManagerSetInputValueMatching(hid, [
+    kIOHIDElementUsagePageKey: kHIDPage_KeyboardOrKeypad,  // 0x07
+    kIOHIDElementUsageKey: kHIDUsage_KeyboardCapsLock      // 0x39
+] as CFDictionary)
+```
+
+> **솔직한 한계**: 매칭은 콜백 수신 범위만 좁힌다. **TCC(Input Monitoring) 권한 요구 자체는 동일** — 권한은 앱 단위로 부여되며, "CapsLock만 모니터" 같은 부분 권한은 존재하지 않는다.
+
+### 생명주기
+
+- 앱 기동 / IMK `activateServer` 시점에서 `toggleKey == .capsLock`이면 `CapsLockHIDMonitor.start()` 시도.
+- 설정 UI에서 전환 키가 `.capsLock`으로 변경되는 순간 시작, 다른 값으로 변경되는 순간 정지.
+- `NSWorkspace.didWakeNotification` / `screensDidWakeNotification` → 재시작.
+
+## 단일 상태 — `CapsLockMode` enum
+
+직전 검토에서 3개 플래그(`isActive`/`realCapsLockActive`/`suppressCapsLockModeSync`)는 사실 한 상태머신을 세 곳에 나눠놓은 형태로 식별됨. **단일 enum으로 통합**한다.
+
+```swift
+enum CapsLockMode {
+    /// HID 모니터 미활성 (toggleKey != .capsLock, 권한 미부여, 충돌 등).
+    /// 기존 CGEventTap 경로가 권위. doc 30 SET 의미론 그대로 동작.
+    case cgEventTapAuthority
+
+    /// HID 모니터 활성, 짧은 탭 모드.
+    /// HID가 press/release 감지, 임계 미만이면 한/영 토글.
+    case hidToggleAuthority
+
+    /// HID 모니터 활성, 길게-누름으로 본연 CapsLock 진입 상태.
+    /// alpha-lock 시스템 상태 ON 유지. 다음 짧은 탭에서 OFF로 환원.
+    case hidRealLockOn
+}
+```
+
+모듈별 해석:
+
+| 모듈 | 동작 |
+|---|---|
+| `KeyEventTap` flagsChanged CapsLock 분기 (doc 30) | `current == .cgEventTapAuthority` 일 때만 실행 |
+| `KeyEventTap` keyDown `.maskAlphaShift` strip ([PR #11](https://github.com/hiking90/ongeul/pull/11)) | `current != .hidRealLockOn` 일 때만 실행 (본연 잠금 중엔 대문자 통과) |
+| `InputStateCoordinator.setMode` LED 동기화 (doc 30) | `current != .hidRealLockOn` 일 때만 LED set (본연 잠금 중엔 사용자 상태 존중) |
+| `CapsLockHIDMonitor` | 자기 자신이 상태 변경의 권위. 시작/정지/타이머 발화/short tap/long press 시 `current`를 변경 |
+
+상태 전이:
+
+```
+cgEventTapAuthority  ──HID start success──▶  hidToggleAuthority
+hidToggleAuthority   ──HID stop / fail──▶   cgEventTapAuthority
+hidToggleAuthority   ──long press fire──▶   hidRealLockOn
+hidRealLockOn        ──next short tap──▶    hidToggleAuthority
+hidRealLockOn        ──HID fail/stop──▶     cgEventTapAuthority  (+ LED off)
+```
+
+## 상태머신 — HID 콜백 본체
+
+```
+        ┌─────────────────────────────────────────────┐
+        │   [CapsOFF]                                 │
+        │     │ HID: keyDown(0x39)                    │
+        │     │   ├─ start 800ms timer                │
+        │     │   ├─ CapsLockSync.setState(false)     │
+        │     │   │  (doc 30 expectedState 가드 적용) │
+        │     │   └─ pressTimestamp = HID ts          │
+        │     ▼                                       │
+        │   [Pressing]                                │
+        │     │                                       │
+        │     ├─ HID: keyUp(0x39) (timer 아직)        │
+        │     │     → coordinator.toggleMode()        │
+        │     │       doc 30이 LED 동기화             │
+        │     │       복귀 ─▶ [CapsOFF]                │
+        │     │                                       │
+        │     └─ Timer 발화 (keyDown 유지 중)         │
+        │           ├─ CapsLockMode = .hidRealLockOn  │
+        │           ├─ CapsLockSync.setState(true)    │
+        │           │  (LED ON, 모드 불변)            │
+        │           └─ 복귀 ─▶ [CapsON]                │
+        │                                             │
+        │   [CapsON]                                  │
+        │     └─ HID: keyDown(0x39)                   │
+        │          ├─ CapsLockMode = .hidToggleAuth.  │
+        │          ├─ CapsLockSync.setState(false)    │
+        │          └─ 토글 안 함                       │
+        │             복귀 ─▶ [CapsOFF]                │
+        └─────────────────────────────────────────────┘
+```
+
+| 현재 | 입력 | 동작 | 다음 |
+|---|---|---|---|
+| CapsOFF | 짧은 탭 (< 800ms) | toggleMode + doc 30 mode-sync로 LED 정합 | CapsOFF (또는 LED=ON if 한글) |
+| CapsOFF | 길게 (≥ 800ms) | `setState(true)` + 토글 억제 + mode=`hidRealLockOn` | CapsON |
+| CapsON | 짧은 탭 | `setState(false)` + mode=`hidToggleAuthority` + 토글 안 함 | CapsOFF |
+| CapsON | 길게 | 짧은 탭과 동일 — `setState(false)` + 종료 | CapsOFF |
+
+## 임계값 — 800ms 하드코딩
+
+**값**: `800ms`. 하드코딩, 설정 UI 미노출.
+
+**근거**:
+- SokIM이 출하 검증한 값. 사용자에게 익숙한 reference.
+- 짧은 탭(통상 50–200ms)과 명확 분리 → 오발동 거의 0.
+- 사용자 설정 노출의 조정 비용 < 단일 값 단순성. 단일 값으로 두고 필요 시 후속에서 조정.
+
+**solid한 trade-off**:
+- macOS 네이티브 *"Press and hold"* 동작은 시스템 Caps Lock 지연(~100–250ms) 위에서 동작 → 사용자가 macOS 기본 IM에서 익숙해진 *체감 임계*는 800ms보다 짧다. 즉 800ms는 **SokIM-parity**이지 **macOS-parity**가 아님. 의도된 보수성(오발동 < 반응성). SokIM 사용자에게는 익숙하지만, macOS 네이티브 사용 경험과는 약간의 *길게 느낌* 차이 발생.
+
+**시스템 값 매칭은 채택하지 않음**:
+- macOS는 Caps Lock 지연을 사용자 UI로 노출하지 않음 (`hidutil` CLI 전용).
+- 99%의 사용자는 Apple 디폴트 상태 → "사용자 시스템 값" 매칭은 사실상 "Apple 디폴트 매칭"에 수렴.
+- 디폴트 값 자체가 정확한 공식 수치 없음(외부 보고 100ms vs 250ms 엇갈림).
+
+## 기존 코드와의 통합
+
+### `CapsLockHIDMonitor.swift` (신규)
+
+```swift
+final class CapsLockHIDMonitor {
+    static let shared = CapsLockHIDMonitor()
+
+    /// 통합 상태. KeyEventTap·InputStateCoordinator가 읽기-전용으로 참조.
+    private(set) var mode: CapsLockMode = .cgEventTapAuthority
+
+    private var hid: IOHIDManager?
+    private var longPressTimer: DispatchWorkItem?
+
+    weak var coordinator: InputStateCoordinator?
+    weak var controller: OngeulInputController?
+
+    /// 800ms — SokIM 출하 검증값.
+    private static let longPressThresholdMs: Int = 800
+
+    /// 시작. 성공 시 mode=.hidToggleAuthority. 권한·충돌 실패 시 throws.
+    func start() throws { /* IOHIDManagerCreate + 매칭 + 콜백 + Open */ }
+    func stop() { /* close + unschedule + mode=.cgEventTapAuthority */ }
+    func restart() { stop(); try? start() }
+
+    /// 콜백 본체 (자세한 의사코드는 § 상태머신 참조).
+    fileprivate func onValue(_ value: IOHIDValue) {
+        let usage = IOHIDElementGetUsage(IOHIDValueGetElement(value))
+        guard usage == kHIDUsage_KeyboardCapsLock else { return }
+        let isDown = IOHIDValueGetIntegerValue(value) != 0
+
+        if isDown {
+            if mode == .hidRealLockOn {
+                exitRealCapsLock()
+                return
+            }
+            scheduleLongPressTimer()
+            CapsLockSync.setState(false)
+        } else { // keyUp
+            longPressTimer?.cancel()
+            if mode == .hidRealLockOn { return }
+            DispatchQueue.main.async { [controller] in
+                controller?.performToggleFromTap()
+            }
+        }
+    }
+
+    private func scheduleLongPressTimer() {
+        let work = DispatchWorkItem { [weak self] in self?.enterRealCapsLock() }
+        longPressTimer = work
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + .milliseconds(Self.longPressThresholdMs),
+            execute: work
+        )
+    }
+
+    private func enterRealCapsLock() {
+        mode = .hidRealLockOn
+        CapsLockSync.setState(true)
+    }
+
+    private func exitRealCapsLock() {
+        mode = .hidToggleAuthority
+        CapsLockSync.setState(false)
+    }
+}
+```
+
+### `KeyEventTap.swift` 수정
+
+```swift
+// flagsChanged 분기 (doc 30이 추가)
+if type == .flagsChanged && keyCode == Int64(KeyCode.capsLock)
+    && KeyEventTap.toggleKey == .capsLock
+    && CapsLockHIDMonitor.shared.mode == .cgEventTapAuthority {  // 게이트
+    // ... 기존 doc 30 로직 (CapsLockSync.shouldHandle + performCapsLockModeSet) ...
+}
+
+// keyDown 방어 ([PR #11](https://github.com/hiking90/ongeul/pull/11))
+if KeyEventTap.toggleKey == .capsLock
+    && flags.contains(.maskAlphaShift) {
+    if CapsLockHIDMonitor.shared.mode == .hidRealLockOn {
+        // 본연 CapsLock ON 중에는 strip·forceOff 면제 → 대문자 통과
+    } else {
+        CapsLockSync.forceOff()
+        flags.subtract(.maskAlphaShift)
+        event.flags = flags
+    }
+}
+```
+
+### `InputStateCoordinator.swift` 수정
+
+doc 30의 `setMode(_, syncCapsLock:)`에 본 doc의 게이트 한 줄:
+
+```swift
+private func setMode(_ mode: InputMode, syncCapsLock: Bool = true) {
+    engine.setMode(mode: mode)
+    KeyEventTap.currentInputMode = mode
+    if syncCapsLock
+        && KeyEventTap.toggleKey == .capsLock
+        && CapsLockHIDMonitor.shared.mode != .hidRealLockOn {  // 본연 잠금 중 LED 건드리지 않음
+        CapsLockSync.setState(mode == .korean)
+    }
+}
+```
+
+### `OngeulInputController.swift` 수정
+
+- `okClicked` 흐름에서 toggleKey 전이 감지 → [§ TCC UX 시트](#tcc--ux-안내-시트) 호출.
+- `applicationDidFinishLaunching` / `activateServer`에서 toggleKey 확인 → HID 모니터 `start()` 시도, 실패 시 헬스 배너 갱신.
+- `CapsLockHIDMonitor.shared.controller`에 self 주입.
+
+## TCC / UX 안내 시트
+
+### 권한 요구
+
+| 권한 | TCC 서비스 | 위치 |
+|---|---|---|
+| 입력 모니터링 (신규) | `kTCCServiceListenEvent` | 개인정보 보호 및 보안 → 입력 모니터링 |
+| 손쉬운 사용 (현행) | `kTCCServiceAccessibility` | 개인정보 보호 및 보안 → 손쉬운 사용 |
+
+### 결손 권한 있을 때만 시트 표시 (게이팅)
+
+매번 다이얼로그를 띄우지 않는다. 두 권한 모두 부여돼 있으면 조용히 진행:
+
+```swift
+import IOKit.hid
+import ApplicationServices
+
+private enum Perm {
+    static var inputMonitoring: Bool {
+        IOHIDCheckAccess(kIOHIDRequestTypeListenEvent) == kIOHIDAccessTypeGranted
+    }
+    static var accessibility: Bool { AXIsProcessTrusted() }
+}
+
+// okClicked, toggleKey 전이 시
+let missingInput  = !Perm.inputMonitoring
+let missingAccess = !Perm.accessibility
+
+if !missingInput && !missingAccess {
+    // 둘 다 부여돼 있음 → 다이얼로그 생략, 즉시 활성
+    commitSetting()
+    try? CapsLockHIDMonitor.shared.start()
+} else {
+    presentCapsLockPermissionSheet(
+        missingInput: missingInput,
+        missingAccess: missingAccess,
+        on: preferencesPanel,
+        onConfirm: {
+            commitSetting()
+            try? CapsLockHIDMonitor.shared.start()
+        },
+        onCancel: { revertToggleKey() }
+    )
+}
+```
+
+`IOHIDCheckAccess`는 프롬프트 트리거 없이 상태만 조회. `IOHIDAccessType.unknown`은 *결손으로 간주* (보수적 디폴트).
+
+### 다이얼로그 — 결손 종류에 따라 동적 구성
+
+| 결손 | 표시 |
+|---|---|
+| 둘 다 부여돼 있음 | 다이얼로그 없음, 즉시 활성 |
+| 입력 모니터링만 결손 (가장 흔함) | 본문 1줄 + 버튼 *"입력 모니터링 설정 열기"* / *"취소"* |
+| 손쉬운 사용만 결손 (이론상) | 본문 1줄 + 버튼 *"손쉬운 사용 설정 열기"* / *"취소"* |
+| 둘 다 결손 | 본문 2줄 + 버튼 *"입력 모니터링 설정 열기"* / *"손쉬운 사용 설정 열기"* / *"취소"* |
+
+딥링크:
+
+```swift
+NSWorkspace.shared.open(URL(string:
+    "x-apple.systempreferences:com.apple.preference.security?Privacy_ListenEvent"
+)!)
+NSWorkspace.shared.open(URL(string:
+    "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+)!)
+```
+
+> **Tahoe 검증 항목**: 위 URL 앵커가 *Privacy & Security 루트가 아니라 정확히 해당 하위 페인까지* 깊이 들어가는지 1분 스파이크. 실패 시 다이얼로그 본문에 수동 경로 텍스트(*"개인정보 보호 및 보안 → 입력 모니터링"*) 함께 표기.
+
+### 상시 헬스체크 배너
+
+- `toggleKey == .capsLock`인데 HID 모니터 `start()` 실패(`kIOReturnNotPermitted` 등) 지속 → 메뉴바 아이콘 옆 작은 경고 또는 메뉴 항목 *"CapsLock 모드: 입력 모니터링 권한 필요"* + 같은 딥링크 버튼.
+- `activateServer` 호출마다 `start()` 재시도. 성공하면 배너 제거.
+- 권한 부여는 macOS가 앱에 통지하지 않음 → 폴링/재시도 패턴이 표준.
+
+### 폴백
+
+| 실패 사유 | 동작 |
+|---|---|
+| 권한 미부여 (`kIOReturnNotPermitted`) | `mode = .cgEventTapAuthority`. doc 30 CGEventTap 경로 그대로 동작 (짧은 탭 한/영 전환만). (B) 길게-누름 미지원. 사용자가 *오늘보다 나빠지지 않음*. |
+| 다른 HID 모니터와 충돌 (`kIOReturnExclusiveAccess`) | 동일 폴백 + *"다른 키보드 모니터링 앱과 충돌"* 안내. Karabiner 호환 분기는 MVP에서 보류. |
+| HID 콜백 침묵 (절전 복귀 등) | `NSWorkspace.didWakeNotification`에서 `restart()`. |
+
+폴백 경로에서도 [PR #11](https://github.com/hiking90/ongeul/pull/11)의 keyDown strip이 작동 → #10 가시 증상은 닫혀 있다.
+
+## 서명·공증 선결조건 (Phase 4 의존성)
+
+[16. 샌드박스와 코드 서명](50-sandbox-and-signing.md)에 정의된 Developer ID + 공증 파이프라인은 본 doc 채택 시 **준 필수**.
+
+- 현재 [build.sh:165](../scripts/build.sh)·[package.sh:67](../scripts/package.sh)·[release.yml](../.github/workflows/release.yml) 모두 `codesign --force --sign -` (ad-hoc) — 공증 없음.
+- ad-hoc 서명에서 TCC는 designated requirement 불안정 → **업데이트/재빌드마다 입력 모니터링 권한이 풀리는 사용자 사례 빈발**. 매번 제거→재추가 UX는 장기 채택 차단 요인.
+- 손쉬운 사용은 [install.sh:63-86](../scripts/install.sh)이 SIP-off 환경에서 TCC.db 직접 주입 우회 중. 입력 모니터링도 SIP-off에서 동일 우회 가능, **일반 사용자 해법 아님**.
+
+→ 본 doc 32 정식 배포는 **doc 50 (Developer ID + 공증) 도입과 한 묶음** 권고. 분리 배포 시 한계를 capslock.md에 명시.
+
+개발/repro 단계에선 install.sh의 SIP-off TCC 자동부여 로직을 `kTCCServiceListenEvent`로 확장하면 e2e 테스트 가능.
+
+## 다른 HID 모니터와의 충돌
+
+| 시나리오 | 동작 |
+|---|---|
+| SokIM·구름·Karabiner-Elements 미설치 | HID 단독 권위. 정상. |
+| SokIM 등 비-seize HID 모니터 공존 | IOHIDManagerOpen `0` (비-seize)는 충돌하지 않음. 양쪽이 `IOHIDSetModifierLockState` 등으로 같은 상태를 다투면 race 잔존 — Ongeul은 본연 잠금 의도가 분명한 시점(`hidRealLockOn`)에만 `setState(true)` 호출하므로 충돌 가능성은 좁힘. |
+| Karabiner-Elements 가상 HID 드라이버 | SokIM은 시리얼 매칭 호환 분기 채택. MVP에선 미지원 — 폴백 + 안내. |
+
+## 동작 시나리오
+
+| # | 상황 | 결과 |
+|---|---|---|
+| 1 | OFF 상태에서 짧게 탭 (전환 키=CapsLock, HID 정상) | HID keyDown → 타이머 시작 + `setState(false)`. keyUp이 임계 전 → `toggleMode()`. doc 30 mode-sync가 LED를 모드에 정합. PR #11 strip 정상. |
+| 2 | OFF 상태에서 800ms 이상 보유 | 타이머 발화 → `mode=.hidRealLockOn` + `setState(true)`. 한/영 토글 안 함. 이후 keyDown들은 strip 면제 → 대문자가 앱에 전달 (스파이크 결과 A 가정). |
+| 3 | ON 상태에서 짧게 탭 | `mode == .hidRealLockOn` 확인 → `exitRealCapsLock()` → `setState(false)` + `mode=.hidToggleAuthority`. 토글 안 함. |
+| 4 | ON 상태에서 한/영 모드가 다른 경로(우커맨드 탭 등)로 변경 | `setMode`가 `mode == .hidRealLockOn` 가드에 막혀 LED 안 건드림 — 사용자가 켠 본연 CapsLock 유지. |
+| 5 | 권한 미부여 | `start()` `kIOReturnNotPermitted` throws → `mode=.cgEventTapAuthority` 유지 → doc 30 CGEventTap 경로. 메뉴바 배너 + 딥링크. (B) 미지원. |
+| 6 | SokIM과 공존 | HID open 성공(비-seize). 양측 상태 set 시도가 겹치면 race — `hidRealLockOn` 시점에만 set ON하므로 일상 짧은 탭은 안전. 사용자 안내 권고. |
+| 7 | 절전 → 복귀 | `didWakeNotification` → `CapsLockHIDMonitor.restart()`. |
+| 8 | 전환 키를 CapsLock→우커맨드로 변경 | `okClicked`에서 `stop()` + `CapsLockSync.reset()` + LED OFF. TCC 권한은 시스템에 남되 모니터는 정지. |
+| 9 | 우커맨드→CapsLock 변경 | UX 시트 (권한 결손 시) 또는 즉시 활성 (권한 둘 다 있음) → `start()`. |
+| 10 | 본연 CapsLock ON 상태에서 IME 전환(앱 변경) | `mode=.hidRealLockOn` 그대로 유지 (전역). macOS Caps Lock 의미론 매칭. |
+| 11 | 암호 필드 진입 (Secure Input) | doc 30 시나리오와 동일. HID 콜백은 계속 들어오지만 `controller.isCurrentAppLocked`/`IsSecureEventInputEnabled` 체크로 coordinator 호출 억제. |
+| 12 | `hidRealLockOn` 상태에서 사용자가 권한 회수 | HID 콜백 중단. 헬스체크가 회수를 탐지하면 `CapsLockSync.setState(false)` + `mode=.cgEventTapAuthority`로 환원. |
+
+## 스파이크 계획
+
+목표: § 가장 큰 단일 가정의 A/B/C 분기 결정.
+
+### 환경
+
+- 우선 [Sequoia repro VM](../README.md) (`ongeul-sequoia`).
+- **Tahoe(macOS 26.x) repro 환경 신규 구축 필수** — 제보자 환경, 현재 미커버.
+
+### 측정 항목 (6개)
+
+1. **상태 set + 입력 검증**: stand-alone 작은 Cocoa 앱에서 `IOHIDSetModifierLockState(service, kIOHIDCapsLockState, true)` 호출 → 직후 키보드로 `a`. NSTextField가 `A`? `a`?
+2. **다양한 대상 앱**: TextEdit·Safari·Terminal·Xcode·Electron 1개 — 텍스트 입력 경로 차이 확인.
+3. **LED 검증**: 호출 후 외부 키보드 LED 켜지는가? (내장 키보드는 LED 없음)
+4. **`CGEventSourceFlagsState(.combinedSessionState).contains(.maskAlphaShift)`**: 즉시 true?
+5. **stomp 검증**: 호출 후 1~2초 관찰. OS가 외부 요인으로 false로 되돌리는가? SokIM 11회 반복 패턴의 현재 OS 유효성.
+6. **HID 콜백이 시스템 Caps Lock 지연과 무관하게 도착하는가?** `hidutil property --set CapsLockDelayOverride 250` 설정 후 짧은 탭 — HID 모니터가 받는가? (받는다면 사용자에게 `hidutil` 안내 불필요화 가능.)
+
+### 예상 시간
+
+- Tahoe VM 구축: 1~2시간
+- 스파이크 코드 작성 + 두 OS 측정 + 관찰: 4~6시간
+- **총 5~8시간**
+
+### 결과별 분기
+
+- **A**: 대문자 전달 OK → 본 doc 그대로 Phase 2 진행.
+- **B**: LED/상태 OK, 앱은 소문자 → 영문 통과 경로에 *uppercase override* 합성 추가 (KeyEventTap의 영문 모드 keyDown post 또는 IMK handle 단계에서 `.uppercased()` 변환). HID 도입 의의는 유지.
+- **C**: stomp 활발, 안정성 부족 → 본 doc 보류. HID는 *짧은 탭 신뢰성만* 한정 채택할지 별도 판단.
+
+## 수정·신규 파일
+
+| 파일 | 종류 | 변경 |
+|---|---|---|
+| `OngeulApp/Sources/CapsLockHIDMonitor.swift` | 신규 | 본 doc § 기존 코드 통합 본체 |
+| `OngeulApp/Sources/CapsLockMode.swift` | 신규 | enum 정의 (또는 `CapsLockHIDMonitor.swift` 내 nested) |
+| `OngeulApp/Sources/CapsLockSync.swift` | 수정 | doc 30: `setState(true/false)` + `expectedState` 가드 |
+| `OngeulApp/Sources/KeyEventTap.swift` | 수정 | flagsChanged CapsLock 분기에 `mode == .cgEventTapAuthority` 게이트, keyDown strip에 `mode != .hidRealLockOn` 게이트 |
+| `OngeulApp/Sources/InputStateCoordinator.swift` | 수정 | `setMode`에 `syncCapsLock` + `mode != .hidRealLockOn` 게이트, `toggleEngineMode` 동기화 |
+| `OngeulApp/Sources/OngeulInputController.swift` | 수정 | `okClicked` 전이 감지 + TCC 시트, HID start 트리거, 헬스 배너, `performCapsLockModeSet` |
+| `OngeulApp/Resources/Localizable.strings` (ko/en) | 수정 | 시트·배너 문구 |
+| `OngeulApp/Resources/Info.plist` | (확인) | `TICapsLockLanguageSwitchCapable` 이미 없음. `NSInputMonitoringUsageDescription` IMK 적용성 검증 필요 |
+| `docs/src/user/features/capslock.md` | 수정 | (B) 길게-누름 지원 명시, 권한 안내, `hidutil` 정정(폴백 한정) |
+| `scripts/install.sh` | 수정 | SIP-off TCC 자동부여를 `kTCCServiceListenEvent`로 확장 (개발 한정) |
+
+## 단계화
+
+| Phase | 내용 | 의존 |
+|---|---|---|
+| **0 (완료)** | [PR #11](https://github.com/hiking90/ongeul/pull/11): CGEventTap keyDown strip — #10 가시 증상 hardening | — |
+| **0.5** | Tahoe repro VM 구축 | 인프라 작업 |
+| **1** | doc 30 구현 (`CapsLockSync.setState/expectedState` + `setMode(syncCapsLock:)` + KeyEventTap flagsChanged 분기 + `performCapsLockModeSet`) | — |
+| **1.5** | 본 doc 스파이크 — A/B/C 결정 | Phase 0.5 |
+| **2** | 본 doc 구현 (`CapsLockHIDMonitor` + `CapsLockMode` enum + 게이팅 + TCC 시트 + 헬스 배너) | Phase 1, 1.5 (결과 A 또는 B) |
+| **3** | 문서 정정 ([capslock.md](../docs/src/user/features/capslock.md): `hidutil` 정정, 길게-누름 지원 명시; HID 모드에서 `hidutil` 안내 불필요 분리) | Phase 2 |
+| **4** | Developer ID + 공증 ([doc 50](50-sandbox-and-signing.md)) | Phase 2와 한 묶음 권고 |
+
+> **PR 직렬화**: 각 Phase의 PR은 *이전 단계가 main에 머지된 후* 베이스를 잡는다 ([메모리: PR base trap](https://github.com/hiking90/ongeul/issues/7)). Phase 1과 Phase 1.5는 독립 — 병행 가능.
+
+## 미해결 / 후속 검토
+
+1. **`hidRealLockOn`의 영속성**: 앱 전환 시 전역 ON 유지로 결정([§ 동작 시나리오](#동작-시나리오) #10). macOS Caps Lock 의미론과 일치하며 사용자 멘탈 모델과도 합치. *전역* 결정으로 doc 32 확정.
+2. **HID 콜백 침묵 자동 복구**: SokIM `restartIfIdle()` 패턴 도입 여부. idle 임계와 false positive 검토.
+3. **`IOHIDSetModifierLockState` Tahoe 동작 차이**: 스파이크에서 정밀화.
+4. **`NSInputMonitoringUsageDescription` IMK 적용성**: IMK 앱은 시스템 launch 백그라운드 프로세스라 표준 TCC 프롬프트 비신뢰. 사용자 매뉴얼(우리 시트) + 딥링크로 우회.
+5. **다중 키보드 동시**: 두 키보드의 CapsLock 거의 동시 누름 시 상태머신 일관성 검증.
+6. **이슈 #10과의 연결**: 본 doc 채택 후 #10 환경 원인(SokIM 공존 / Tahoe race) 중 무엇이 실제였는지 사후 회고 필요. PR #11으로 충분히 닫혔는지, 본 doc 구현 후에야 닫히는지 분리 검증.
+
+---
+
+## 참고
+
+- [30. CapsLock LED 기반 한영 모드 동기화](30-capslock-mode-sync.md)
+- [50. 샌드박스와 코드 서명](50-sandbox-and-signing.md)
+- [capslock-hangul-toggle.md](capslock-hangul-toggle.md) — 가장 초기의 CapsLock 검토
+- [PR #11 — fix(capslock): strip stale maskAlphaShift on keyDown](https://github.com/hiking90/ongeul/pull/11)
+- [이슈 #10](https://github.com/hiking90/ongeul/issues/10)
+- [SokIM `InputMonitor.swift`](https://github.com/kiding/SokIM/blob/main/SokIM/InputMonitor.swift) — IOHIDManager + 800ms 길게-누름 참조 구현
+- [SokIM `Helpers.swift`](https://github.com/kiding/SokIM/blob/main/SokIM/Helpers.swift) — `setKeyboardCapsLock` 본체 (LED-only + Sonoma stomp 대응 패턴)
+- Apple Input Sources 설정 옵션: *"Use the Caps Lock key to switch to and from U.S. **Press and hold to enable typing in all uppercase**."*

--- a/docs/src/user/features/capslock.md
+++ b/docs/src/user/features/capslock.md
@@ -9,15 +9,21 @@ Ongeul은 CapsLock을 한/영 전환 키로 사용하거나, CapsLock 상태를 
 ### 동작 방식
 
 - CapsLock을 누를 때마다 한글/영문 모드가 전환됩니다.
-- CapsLock LED는 항상 꺼진 상태로 유지됩니다. 대문자 잠금 기능은 비활성화됩니다.
+- **CapsLock LED가 현재 입력 모드를 나타냅니다**: LED ON = 한글, LED OFF = 영문. 모드가 다른 경로(다른 전환 키 사용, 앱 전환에 따른 per-app 모드 복원 등)로 바뀌어도 LED가 자동으로 동기화됩니다.
+- 본연의 대문자 잠금 기능은 비활성화됩니다 (CapsLock = 한/영 전환 키 용도). 대문자 잠금이 필요하면 다른 전환 키(우측 Command/Option 등)를 선택하세요.
 - [영문 잠금](english-lock.md) 상태에서는 CapsLock이 기존 대문자 잠금으로 동작합니다.
 
 ### 사전 설정
 
-**시스템 설정 → 키보드**에서 다음을 확인하세요:
+1. **macOS CapsLock 지연 해제** — macOS는 CapsLock에 약 100–250ms 지연을 적용해 빠른 탭을 무시합니다. 이 지연을 끄지 않으면 짧은 탭으로 한/영 전환이 안 됩니다. macOS는 이 지연을 위한 시스템 설정 UI를 제공하지 *않으므로*, **터미널**에서 다음 명령으로 끕니다:
 
-1. **CapsLock 지연 비활성화** — CapsLock 입력 지연을 끄세요. 지연이 활성화되어 있으면 CapsLock을 빠르게 누를 때 전환이 무시될 수 있습니다.
-2. **"Caps Lock으로 ABC 입력 소스 전환"** 옵션 비활성화 — 이 옵션이 켜져 있으면 CapsLock을 누를 때 Ongeul에서 ABC로 전환되어 버립니다.
+    ```bash
+    hidutil property --set '{"CapsLockDelayOverride":0}'
+    ```
+
+    이 설정은 재부팅 시 초기화됩니다. 영구화하려면 LaunchAgent 등록이 필요합니다 (외부 참고: [CapsLockNoDelay](https://github.com/gkpln3/CapsLockNoDelay)).
+
+2. **"Caps Lock 키로 ABC 입력 소스 전환" 옵션 비활성화** — **시스템 설정 → 키보드 → 입력 소스 → 편집...** 에서 *"Caps Lock 키로 ABC 입력 소스 전환"* 옵션을 끕니다. 켜져 있으면 CapsLock을 누를 때 macOS가 먼저 ABC로 전환해 Ongeul이 비활성화됩니다.
 
 ## CapsLock 정규화
 


### PR DESCRIPTION
## Summary

Implements [`design/30-capslock-mode-sync.md`](design/30-capslock-mode-sync.md)
(previously "2차 검토 완료 — 구현 대기"): the system Caps Lock LED becomes a
**mirror of the current input mode** — LED ON = Korean, LED OFF = English. Any
mode change (CapsLock press, other toggle keys, per-app restore on app switch,
English Lock, ESC→English, focus-steal correction) auto-syncs the LED via
`IOHIDSetModifierLockState`. An `expectedState` + 100 ms guard filters the
software's own echo `flagsChanged`s from real user input.

This PR is the **Phase 1** half of the broader CapsLock-toggle work.
Phase 2 (HID-based short/long-press parity) follows as a separate stacked PR.

> Re-review of the earlier monolithic [PR #12](https://github.com/hiking90/ongeul/pull/12) recommended splitting into Phase 1 + Phase 2 for cleaner review and merge-isolation. This PR + the Phase 2 PR replace #12. See [§ Replaces PR #12](#replaces-pr-12).

## What changes

| Layer | Change |
|---|---|
| `OngeulApp/Sources/CapsLockSync.swift` | Adds `setState(_: Bool)`, `shouldHandle(capsLockOn:)`, `reset()`; old `forceOff()` retained as alias (removed in Phase 2 PR). `expectedState` + 100 ms timeout guard filters software echoes. |
| `OngeulApp/Sources/InputStateCoordinator.swift` | `setMode(_, syncCapsLock: Bool = true)` and `toggleEngineMode` now sync LED when `toggleKey == .capsLock`. Default true; `syncCapsLock: false` for the CapsLock-press path where hardware already toggled. New public `setModeFromCapsLockPress(korean:for:)`. |
| `OngeulApp/Sources/KeyEventTap.swift` | flagsChanged CapsLock branch refactored from "always forceOff + toggle" to SET semantics with `shouldHandle()` filtering and `performCapsLockModeSet(korean:)` dispatch. |
| `OngeulApp/Sources/OngeulInputController.swift` | New `performCapsLockModeSet(korean:)`. IMK fallback `handleFlagsChanged` CapsLock branch migrated to same SET semantics. |
| `OngeulApp/Resources/*.lproj/Localizable.strings` | `prefs.capsLockDelay` tooltip corrected — macOS has no UI to disable the Caps Lock delay; `hidutil` is required (see capslock.md). |
| `docs/src/user/features/capslock.md` | "LED behavior" description reframed to match doc 30 (ON=Korean, OFF=English). "사전 설정" rewritten with the actual `hidutil property --set '{"CapsLockDelayOverride":0}'` command (with persistence note). |
| `design/32-hid-capslock-press-duration.md` | Forward-looking design for Phase 2 (HID press-duration) included here for context. Code that depends on this design lands in the Phase 2 PR. |

## Includes PR #11's keyDown strip

This branch was branched off [PR #11](https://github.com/hiking90/ongeul/pull/11), so it contains commit `3acfafc` — the equivalent of #11's CapsLock keyDown `.maskAlphaShift` strip (#10 hardening).

- If **PR #11 merges first** → this PR rebases cleanly (GitHub deduplicates the identical commit).
- If **this PR merges first** → #11 becomes redundant and can be closed.

Recommended order: merge #11 first.

## Verification

`swiftc -typecheck` of all sources (Generated + `OngeulApp/Sources/*.swift`) passes with **zero warnings** on this branch. Runtime verification is recommended on Sequoia (`ongeul-sequoia` repro VM) and Tahoe (no VM yet — separate Phase 0.5 infrastructure work).

## Replaces PR #12

[PR #12](https://github.com/hiking90/ongeul/pull/12) bundled Phase 1 + Phase 2 in one ~990-line PR. Re-review identified:

1. Phase 2 code was committed *before* the spike that determines whether `IOHIDSetModifierLockState(true)` actually delivers uppercase — a methodology violation
2. Phase 2's `exitRealCapsLock` broke macOS-native parity (two-action exit vs single-action)
3. Phase 2's `commitSettings` had a controller-injection race
4. Doc 32 was missing a spike measurement for `expectedState` timeout OS-load sensitivity
5. `forceOff()` alias was a code smell

Phase 1 (this PR) is the foundation. Phase 2 (the next PR) is gated on the spike and includes fixes for items 2–5 above. #12 will be closed in favor of this split.

## What's NOT in this PR

- ⏸ HID monitor / long-press support → **Phase 2 PR**
- ⏸ Phase 1.5 spike validating `IOHIDSetModifierLockState(true)` → Phase 2 prerequisite
- ⏸ Developer ID + notarization ([doc 50](design/50-sandbox-and-signing.md)) → independent Phase 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
