### PR TITLE
feat(capslock): Phase 2 — HID press-duration monitor (long-press = real Caps Lock)

### DIFF
--- a/OngeulApp/Resources/Info.plist
+++ b/OngeulApp/Resources/Info.plist
@@ -36,6 +36,16 @@
     <key>LSUIElement</key>
     <true/>
 
+    <!-- TCC usage descriptions —
+         macOS는 이 키들이 Info.plist에 존재해야 TCC가 앱을 등록한다.
+         특히 NSInputMonitoringUsageDescription이 없으면 IOHIDManagerOpen 호출이
+         TCC 리스트에 앱을 노출시키지 못한다. -->
+    <key>NSAccessibilityUsageDescription</key>
+    <string>Ongeul이 시스템 레벨에서 전환 키(Shift+Space, 우측 Command 등), ESC→영문 전환, focus-steal 보정 등을 처리하기 위해 손쉬운 사용 권한이 필요합니다.</string>
+
+    <key>NSInputMonitoringUsageDescription</key>
+    <string>Ongeul이 CapsLock 키의 짧게/길게 누름을 구별해 한/영 전환과 본연의 대문자 잠금을 모두 지원하려면 입력 모니터링 권한이 필요합니다. (전환 키를 CapsLock으로 선택한 경우에만 사용.)</string>
+
     <key>InputMethodConnectionName</key>
     <string>io.github.hiking90.inputmethod.Ongeul_Connection</string>
 

--- a/OngeulApp/Resources/en.lproj/Localizable.strings
+++ b/OngeulApp/Resources/en.lproj/Localizable.strings
@@ -22,6 +22,18 @@
 "prefs.toggleKey.capsLock" = "CapsLock";
 "prefs.capsLockDelay" = "macOS has no UI to disable CapsLock delay; hidutil is required — see documentation.";
 
+/* CapsLock permission sheet (shown on first selection of CapsLock toggle) */
+"prefs.capsLockSheet.title"      = "Use CapsLock as Korean/English Toggle";
+"prefs.capsLockSheet.intro"      = "Tap CapsLock to toggle Korean/English. Press and hold to activate the conventional Caps Lock (uppercase).";
+"prefs.capsLockSheet.needInput"  = "This feature requires the Input Monitoring permission.";
+"prefs.capsLockSheet.needAccess" = "This feature requires the Accessibility permission.";
+"prefs.capsLockSheet.restart"    = "After granting permissions, reselect the input source or log out and back in.";
+"prefs.capsLockSheet.openInput"  = "Open Input Monitoring Settings";
+"prefs.capsLockSheet.openAccess" = "Open Accessibility Settings";
+
+/* Menu bar warning when CapsLock HID monitor lacks permission */
+"menu.capsLockNeedsPermission" = "⚠ CapsLock: Input Monitoring Permission Required";
+
 /* Escape → English */
 "prefs.escapeToEnglish" = "Switch to English on ESC / Ctrl+[ (Vim mode)";
 

--- a/OngeulApp/Resources/ko.lproj/Localizable.strings
+++ b/OngeulApp/Resources/ko.lproj/Localizable.strings
@@ -22,6 +22,18 @@
 "prefs.toggleKey.capsLock" = "CapsLock";
 "prefs.capsLockDelay" = "macOS 자체 UI로는 CapsLock 지연을 끄지 못합니다. 터미널에서 hidutil 명령 필요 — 자세한 안내는 문서 참고.";
 
+/* CapsLock 권한 안내 시트 (CapsLock 전환 키 신규 선택 시) */
+"prefs.capsLockSheet.title"      = "CapsLock을 한/영 전환 키로 사용";
+"prefs.capsLockSheet.intro"      = "CapsLock을 짧게 누르면 한/영 전환, 길게 누르면 본연의 대문자 잠금이 활성화됩니다.";
+"prefs.capsLockSheet.needInput"  = "이 기능에는 입력 모니터링 권한이 필요합니다.";
+"prefs.capsLockSheet.needAccess" = "이 기능에는 손쉬운 사용 권한이 필요합니다.";
+"prefs.capsLockSheet.restart"    = "권한 부여 후 입력기를 다시 선택하거나 로그아웃/로그인이 필요합니다.";
+"prefs.capsLockSheet.openInput"  = "입력 모니터링 설정 열기";
+"prefs.capsLockSheet.openAccess" = "손쉬운 사용 설정 열기";
+
+/* 메뉴바: CapsLock HID 모니터 권한 결손 안내 */
+"menu.capsLockNeedsPermission" = "⚠ CapsLock: 입력 모니터링 권한 필요";
+
 /* Escape → English */
 "prefs.escapeToEnglish" = "ESC / Ctrl+[ 키로 영문 전환 (Vim 모드)";
 

--- a/OngeulApp/Sources/CapsLockHIDMonitor.swift
+++ b/OngeulApp/Sources/CapsLockHIDMonitor.swift
@@ -1,0 +1,230 @@
+import Foundation
+import IOKit
+import IOKit.hid
+import os.log
+
+private let log = OSLog(subsystem: "io.github.hiking90.inputmethod.Ongeul", category: "capsLockHID")
+
+/// CapsLock 전용 HID 모니터의 권위 상태 — [doc 32](../../design/32-hid-capslock-press-duration.md) § 단일 상태.
+///
+/// 단일 enum으로 *HID 활성 여부*와 *본연 CapsLock 진입 여부*를 함께 표현하여
+/// 세 곳(KeyEventTap·InputStateCoordinator·CapsLockHIDMonitor)이 같은 값을 본다.
+enum CapsLockMode {
+    /// HID 모니터 미활성 — `toggleKey != .capsLock`, 권한 미부여, HID open 실패, 충돌 등.
+    /// 기존 CGEventTap 경로(doc 30 SET 의미론)가 권위.
+    case cgEventTapAuthority
+
+    /// HID 모니터 활성, 짧은 탭 모드 — 본연 CapsLock 잠금 없음.
+    /// HID가 keyDown/keyUp을 가지고 short/long 판정의 권위.
+    case hidToggleAuthority
+
+    /// HID 모니터 활성, 길게-누름으로 본연 CapsLock 진입 상태.
+    /// alpha-lock = true, LED ON. 모드는 영문 고정(macOS native parity).
+    /// 다음 짧은 탭에서 OFF로 환원.
+    case hidRealLockOn
+}
+
+/// CapsLock 전용 HID 모니터 — [doc 32](../../design/32-hid-capslock-press-duration.md).
+///
+/// `IOHIDManager`로 키보드 디바이스의 CapsLock usage(0x39)만 매칭하여 raw make/break를 받는다.
+/// 짧은 탭(<800ms)은 한/영 토글, 길게-누름(≥800ms)은 본연 CapsLock 활성화.
+///
+/// 옵트인: `toggleKey == .capsLock`이고 사용자가 입력 모니터링 권한을 부여한 경우에만 기동.
+final class CapsLockHIDMonitor {
+    static let shared = CapsLockHIDMonitor()
+    private init() {}
+
+    /// 외부에서 읽기만. 상태 전이는 본 클래스가 단독 수행.
+    private(set) var mode: CapsLockMode = .cgEventTapAuthority
+
+    /// controller 주입 — 짧은 탭의 toggleMode·길게의 enterRealCapsLock 위임.
+    weak var controller: OngeulInputController?
+
+    /// 길게-누름 임계값. SokIM 출하 검증값과 동일. [doc 32 § 임계값](../../design/32-hid-capslock-press-duration.md#임계값--800ms-하드코딩).
+    private static let longPressThresholdMs: Int = 800
+
+    private var hid: IOHIDManager?
+    private var isKeyDown: Bool = false
+    /// 현재 진행 중인 press가 임계 발화로 `.hidRealLockOn` 진입을 일으켰는지.
+    /// keyUp에서 *exit press의 up*(=다음 press의 up)인지 *진입 press의 up*인지 구별.
+    private var pressTriggeredLockTransition: Bool = false
+    private var longPressTimer: DispatchWorkItem?
+
+    /// `start()` 실패 사유.
+    enum StartError: Error, CustomStringConvertible {
+        case notPermitted
+        case exclusiveAccess
+        case other(IOReturn)
+
+        var description: String {
+            switch self {
+            case .notPermitted:    return "입력 모니터링 권한이 필요합니다."
+            case .exclusiveAccess: return "키보드 입력을 모니터링하는 다른 앱과 충돌합니다."
+            case .other(let r):    return "HID 오픈 실패 (\(r))"
+            }
+        }
+    }
+
+    /// 외부에서 HID 모니터 활성 여부 빠른 조회.
+    var isStarted: Bool { hid != nil }
+
+    /// IOHIDManager 생성 + CapsLock-only 매칭 + 콜백 등록 + Open.
+    /// 이미 시작돼 있으면 멱등 (return). 실패 시 throws.
+    func start() throws {
+        if hid != nil {
+            os_log("start: already started", log: log, type: .debug)
+            return
+        }
+
+        let manager = IOHIDManagerCreate(kCFAllocatorDefault, 0)
+
+        IOHIDManagerSetDeviceMatching(manager, [
+            kIOHIDDeviceUsagePageKey: kHIDPage_GenericDesktop,
+            kIOHIDDeviceUsageKey: kHIDUsage_GD_Keyboard
+        ] as CFDictionary)
+
+        // Caps Lock(0x39) usage만 받음 — 다른 키엔 개입 안 함.
+        IOHIDManagerSetInputValueMatching(manager, [
+            kIOHIDElementUsagePageKey: kHIDPage_KeyboardOrKeypad,
+            kIOHIDElementUsageKey: kHIDUsage_KeyboardCapsLock
+        ] as CFDictionary)
+
+        IOHIDManagerRegisterInputValueCallback(manager, { context, result, _, value in
+            guard result == kIOReturnSuccess else { return }
+            guard let context = context else { return }
+            let monitor = Unmanaged<CapsLockHIDMonitor>.fromOpaque(context).takeUnretainedValue()
+            monitor.onValue(value)
+        }, Unmanaged.passUnretained(self).toOpaque())
+
+        IOHIDManagerScheduleWithRunLoop(manager, CFRunLoopGetMain(), CFRunLoopMode.defaultMode.rawValue)
+
+        let res = IOHIDManagerOpen(manager, 0)
+        switch res {
+        case kIOReturnSuccess:
+            os_log("start: success", log: log, type: .info)
+            self.hid = manager
+            self.mode = .hidToggleAuthority
+        case kIOReturnNotPermitted:
+            os_log("start: not permitted (Input Monitoring TCC)", log: log, type: .error)
+            IOHIDManagerClose(manager, 0)
+            throw StartError.notPermitted
+        case kIOReturnExclusiveAccess:
+            os_log("start: exclusive access conflict", log: log, type: .error)
+            IOHIDManagerClose(manager, 0)
+            throw StartError.exclusiveAccess
+        default:
+            os_log("start: other error %d", log: log, type: .error, res)
+            IOHIDManagerClose(manager, 0)
+            throw StartError.other(res)
+        }
+    }
+
+    /// HID 모니터 정지 + 상태 초기화. 멱등.
+    func stop() {
+        if let hid {
+            IOHIDManagerClose(hid, 0)
+            IOHIDManagerUnscheduleFromRunLoop(hid, CFRunLoopGetMain(), CFRunLoopMode.defaultMode.rawValue)
+            IOHIDManagerRegisterInputValueCallback(hid, nil, nil)
+            self.hid = nil
+        }
+        longPressTimer?.cancel()
+        longPressTimer = nil
+        isKeyDown = false
+        pressTriggeredLockTransition = false
+        if mode != .cgEventTapAuthority {
+            mode = .cgEventTapAuthority
+        }
+        os_log("stop: done", log: log, type: .info)
+    }
+
+    /// 절전 복귀 등에서 모니터 재시작.
+    func restart() {
+        stop()
+        try? start()
+    }
+
+    // MARK: - HID 콜백 본체
+
+    private func onValue(_ value: IOHIDValue) {
+        let usage = IOHIDElementGetUsage(IOHIDValueGetElement(value))
+        guard usage == kHIDUsage_KeyboardCapsLock else { return }
+        let isDown = IOHIDValueGetIntegerValue(value) != 0
+        if isDown {
+            onKeyDown()
+        } else {
+            onKeyUp()
+        }
+    }
+
+    private func onKeyDown() {
+        isKeyDown = true
+        pressTriggeredLockTransition = false
+        if mode == .hidRealLockOn {
+            // exit press 시작 — keyUp에서 exitRealCapsLock 실행.
+            os_log("keyDown (exit press starts; mode=hidRealLockOn)", log: log, type: .debug)
+            return
+        }
+        // 일반 toggle press
+        os_log("keyDown (toggle press starts)", log: log, type: .debug)
+        // macOS 하드웨어가 alpha-lock을 토글했을 수 있음 → 즉시 OFF (LED 깜빡임 차단).
+        // CapsLockSync.expectedState 가드가 echo flagsChanged를 필터링.
+        CapsLockSync.setState(false)
+        scheduleLongPressTimer()
+    }
+
+    private func onKeyUp() {
+        isKeyDown = false
+        longPressTimer?.cancel()
+        longPressTimer = nil
+        if mode == .hidRealLockOn {
+            if pressTriggeredLockTransition {
+                // 이 press에서 길게-누름 발화. enterRealCapsLock 이미 실행됨. 추가 동작 없음.
+                os_log("keyUp (entry press completed)", log: log, type: .debug)
+                pressTriggeredLockTransition = false
+            } else {
+                // 이전 press가 .hidRealLockOn 진입시켰고, 새 press(=exit press)의 up이 도착 → exit.
+                os_log("keyUp (exit press completed)", log: log, type: .debug)
+                exitRealCapsLock()
+            }
+        } else {
+            // .hidToggleAuthority — 짧은 탭 완료 → 한/영 토글
+            os_log("keyUp (short tap → toggle)", log: log, type: .debug)
+            DispatchQueue.main.async { [weak controller] in
+                controller?.performToggleFromTap()
+            }
+        }
+    }
+
+    private func scheduleLongPressTimer() {
+        let work = DispatchWorkItem { [weak self] in
+            self?.onLongPressTimerFired()
+        }
+        longPressTimer = work
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + .milliseconds(Self.longPressThresholdMs),
+            execute: work
+        )
+    }
+
+    private func onLongPressTimerFired() {
+        guard isKeyDown else { return }  // race safety: keyUp이 발화 직전 도착
+        pressTriggeredLockTransition = true
+        enterRealCapsLock()
+    }
+
+    private func enterRealCapsLock() {
+        os_log("enterRealCapsLock", log: log, type: .info)
+        // mode를 먼저 변경 → 이후 setMode 호출이 LED 동기화 게이트(`mode != .hidRealLockOn`)에 걸림.
+        mode = .hidRealLockOn
+        DispatchQueue.main.async { [weak controller] in
+            controller?.performEnterRealCapsLock()
+        }
+    }
+
+    private func exitRealCapsLock() {
+        os_log("exitRealCapsLock", log: log, type: .info)
+        mode = .hidToggleAuthority
+        CapsLockSync.setState(false)  // LED off
+        // mode(엔진 입력 모드)는 변경하지 않음 — 사용자가 진입 시 SET한 영문 그대로 유지.
+    }
+}

--- a/OngeulApp/Sources/CapsLockHIDMonitor.swift
+++ b/OngeulApp/Sources/CapsLockHIDMonitor.swift
@@ -263,4 +263,28 @@ final class CapsLockHIDMonitor {
             CapsLockSync.setState(false)
         }
     }
+
+    /// 세션 종료(앱 전환/포커스 상실)로 realLockOn을 강제 해제 (doc 32 §10).
+    ///
+    /// realLockOn은 영문 모드에 커플링돼 있어 다른 앱으로 끌고 가면 엔진 모드 drift가
+    /// 발생한다(전역 LED·flag는 ON인데 per-app 복원이 엔진을 다른 모드로 바꿈). 따라서
+    /// realLockOn을 *세션 한정* 으로 두고 IMK `deactivateServer`에서 강제 해제한다.
+    ///
+    /// HID 콜백이 아닌 IMK 생명주기(메인 스레드)에서 호출되므로 controller dispatch 불필요.
+    /// LED는 여기서 OFF 처리하고, 진입 직전 모드를 반환하여 호출자가 엔진 모드 복원에 쓰게 한다.
+    @discardableResult
+    func exitRealLockForSessionEnd() -> InputMode? {
+        guard mode == .hidRealLockOn else { return nil }
+        let prev = modeBeforeRealLock
+        modeBeforeRealLock = nil
+        pressTriggeredLockTransition = false
+        isKeyDown = false
+        longPressTimer?.cancel()
+        longPressTimer = nil
+        mode = .hidToggleAuthority
+        CapsLockSync.setState(false)
+        os_log("exitRealLockForSessionEnd (restore=%{public}@)",
+               log: log, type: .info, String(describing: prev ?? .english))
+        return prev
+    }
 }

--- a/OngeulApp/Sources/CapsLockHIDMonitor.swift
+++ b/OngeulApp/Sources/CapsLockHIDMonitor.swift
@@ -73,12 +73,29 @@ final class CapsLockHIDMonitor {
 
     /// IOHIDManager 생성 + CapsLock-only 매칭 + 콜백 등록 + Open.
     /// 이미 시작돼 있으면 멱등 (return). 실패 시 throws.
+    ///
+    /// **TCC 등록 보장 (IOHIDRequestAccess)**:
+    /// `IOHIDManagerOpen` 만으로는 최근 macOS (Sonoma/Sequoia/Tahoe)에서 앱이 시스템 설정 →
+    /// 입력 모니터링 리스트에 *등록조차 되지 않는* 사례가 있다. Apple이 문서화한 등록 트리거
+    /// API는 `IOHIDRequestAccess(kIOHIDRequestTypeListenEvent)`. 호출 결과(true/false)는
+    /// 기능적으로는 의미 없으나(이미 granted면 true), **호출 자체의 부수효과로 TCC.db에
+    /// 앱 항목이 생성되어 리스트에 노출되는 것이 핵심**. 모든 start() 호출에서 IOHIDManagerOpen
+    /// 이전에 unconditional하게 호출한다 (멱등, granted 상태에선 no-op).
     func start() throws {
         if hid != nil {
             os_log("start: already started", log: log, type: .debug)
             return
         }
 
+        // 1) TCC 등록 트리거 — Apple 권장 등록 API. IOHIDManagerOpen 이전에 호출 필수.
+        let checkBefore = IOHIDCheckAccess(kIOHIDRequestTypeListenEvent)
+        let requestResult = IOHIDRequestAccess(kIOHIDRequestTypeListenEvent)
+        let checkAfter = IOHIDCheckAccess(kIOHIDRequestTypeListenEvent)
+        os_log("start: TCC check before=%{public}d, RequestAccess=%{public}d, check after=%{public}d",
+               log: log, type: .info,
+               checkBefore.rawValue, requestResult, checkAfter.rawValue)
+
+        // 2) IOHIDManager 설정 + Open
         let manager = IOHIDManagerCreate(kCFAllocatorDefault, 0)
 
         IOHIDManagerSetDeviceMatching(manager, [
@@ -104,19 +121,19 @@ final class CapsLockHIDMonitor {
         let res = IOHIDManagerOpen(manager, 0)
         switch res {
         case kIOReturnSuccess:
-            os_log("start: success", log: log, type: .info)
+            os_log("start: IOHIDManagerOpen success", log: log, type: .info)
             self.hid = manager
             self.mode = .hidToggleAuthority
         case kIOReturnNotPermitted:
-            os_log("start: not permitted (Input Monitoring TCC)", log: log, type: .error)
+            os_log("start: IOHIDManagerOpen not permitted (Input Monitoring TCC)", log: log, type: .error)
             IOHIDManagerClose(manager, 0)
             throw StartError.notPermitted
         case kIOReturnExclusiveAccess:
-            os_log("start: exclusive access conflict", log: log, type: .error)
+            os_log("start: IOHIDManagerOpen exclusive access conflict", log: log, type: .error)
             IOHIDManagerClose(manager, 0)
             throw StartError.exclusiveAccess
         default:
-            os_log("start: other error %d", log: log, type: .error, res)
+            os_log("start: IOHIDManagerOpen other error %{public}d", log: log, type: .error, res)
             IOHIDManagerClose(manager, 0)
             throw StartError.other(res)
         }

--- a/OngeulApp/Sources/CapsLockHIDMonitor.swift
+++ b/OngeulApp/Sources/CapsLockHIDMonitor.swift
@@ -49,6 +49,9 @@ final class CapsLockHIDMonitor {
     /// keyUp에서 *exit press의 up*(=다음 press의 up)인지 *진입 press의 up*인지 구별.
     private var pressTriggeredLockTransition: Bool = false
     private var longPressTimer: DispatchWorkItem?
+    /// 본연 CapsLock 진입 직전의 입력 모드. exit 시 이 모드로 복원 (macOS native parity).
+    /// macOS: "한글 → 길게 → English+caps → 짧은 탭 → 한글 (caps off)"가 단일 동작 시퀀스.
+    private var modeBeforeRealLock: InputMode?
 
     /// `start()` 실패 사유.
     enum StartError: Error, CustomStringConvertible {
@@ -131,6 +134,7 @@ final class CapsLockHIDMonitor {
         longPressTimer = nil
         isKeyDown = false
         pressTriggeredLockTransition = false
+        modeBeforeRealLock = nil
         if mode != .cgEventTapAuthority {
             mode = .cgEventTapAuthority
         }
@@ -213,7 +217,11 @@ final class CapsLockHIDMonitor {
     }
 
     private func enterRealCapsLock() {
-        os_log("enterRealCapsLock", log: log, type: .info)
+        // 진입 직전 모드 기록 — exit에서 복원 (macOS native parity).
+        // KeyEventTap.currentInputMode가 InputStateCoordinator.setMode와 동기화돼 있음.
+        modeBeforeRealLock = KeyEventTap.currentInputMode
+        os_log("enterRealCapsLock (prev=%{public}@)",
+               log: log, type: .info, String(describing: modeBeforeRealLock ?? .english))
         // mode를 먼저 변경 → 이후 setMode 호출이 LED 동기화 게이트(`mode != .hidRealLockOn`)에 걸림.
         mode = .hidRealLockOn
         DispatchQueue.main.async { [weak controller] in
@@ -222,9 +230,20 @@ final class CapsLockHIDMonitor {
     }
 
     private func exitRealCapsLock() {
-        os_log("exitRealCapsLock", log: log, type: .info)
+        let prev = modeBeforeRealLock
+        modeBeforeRealLock = nil
         mode = .hidToggleAuthority
-        CapsLockSync.setState(false)  // LED off
-        // mode(엔진 입력 모드)는 변경하지 않음 — 사용자가 진입 시 SET한 영문 그대로 유지.
+        os_log("exitRealCapsLock (restore=%{public}@)",
+               log: log, type: .info, String(describing: prev ?? .english))
+        if let prev = prev {
+            // macOS native parity: 진입 직전 모드로 복원 (LED도 자동 동기화).
+            // 즉 "한글 → 길게 → 영문+caps → 짧은 탭" 시퀀스가 한국어로 환원되어 끝남.
+            DispatchQueue.main.async { [weak controller] in
+                controller?.performExitRealCapsLock(restoreMode: prev)
+            }
+        } else {
+            // 안전망 — 모드 정보 없으면 LED만 끔.
+            CapsLockSync.setState(false)
+        }
     }
 }

--- a/OngeulApp/Sources/CapsLockSync.swift
+++ b/OngeulApp/Sources/CapsLockSync.swift
@@ -68,10 +68,4 @@ enum CapsLockSync {
     static func reset() {
         setState(false)
     }
-
-    /// 하위 호환: 기존 호출자(설정 패널·KeyEventTap keyDown 방어 등)가 사용.
-    /// 기능적으로 `setState(false)`와 동일.
-    static func forceOff() {
-        setState(false)
-    }
 }

--- a/OngeulApp/Sources/InputStateCoordinator.swift
+++ b/OngeulApp/Sources/InputStateCoordinator.swift
@@ -180,6 +180,13 @@ final class InputStateCoordinator: FocusStealModeController {
         }
     }
 
+    /// 본연 CapsLock 세션 종료 시 엔진 모드만 복원 (doc 32 §10).
+    /// `deactivateServer`에서 호출 — 이후 `deactivate(for:)`가 복원된 모드를 per-app store에 저장한다.
+    /// LED는 HID 게이트(`mode != .cgEventTapAuthority`)로 건드리지 않음.
+    func restoreModeAfterRealLock(_ mode: InputMode) {
+        setMode(mode, syncCapsLock: false)
+    }
+
     /// 시스템 발 모드 변경 (setValue:forTag:client: 경유).
     /// UI/아이콘은 이미 시스템이 변경했으므로 내부 상태만 동기화.
     /// flush 결과를 반환하여 호출자가 client에 적용할 수 있도록 한다.

--- a/OngeulApp/Sources/InputStateCoordinator.swift
+++ b/OngeulApp/Sources/InputStateCoordinator.swift
@@ -40,21 +40,27 @@ final class InputStateCoordinator: FocusStealModeController {
     /// - `toggleKey == .capsLock`일 때 LED를 모드에 동기화한다(LED ON = 한글).
     ///   `syncCapsLock: false`는 CapsLock 누름 자체가 모드 변경을 일으킨 경로에서 사용:
     ///   하드웨어가 이미 LED를 변경했으므로 재설정은 echo만 만들 뿐 (shouldHandle이 걸러내긴 하지만 불필요).
+    /// - 본연 CapsLock 잠금(`hidRealLockOn`) 동안은 사용자가 명시적으로 켠 LED 상태를 존중 —
+    ///   모드 변경이 LED를 건드리지 않는다 (doc 32).
     private func setMode(_ mode: InputMode, syncCapsLock: Bool = true) {
         engine.setMode(mode: mode)
         KeyEventTap.currentInputMode = mode
-        if syncCapsLock && KeyEventTap.toggleKey == .capsLock {
+        if syncCapsLock
+            && KeyEventTap.toggleKey == .capsLock
+            && CapsLockHIDMonitor.shared.mode != .hidRealLockOn {
             CapsLockSync.setState(mode == .korean)
         }
     }
 
-    /// `engine.toggleMode()` 직접 호출 경로(다른 전환 키, IMK fallback 등).
+    /// `engine.toggleMode()` 직접 호출 경로(다른 전환 키, IMK fallback, HID 짧은 탭 등).
     /// setMode를 거치지 않으므로 KeyEventTap·CapsLock LED 동기화를 직접 수행.
+    /// 본연 CapsLock 잠금 동안은 LED 건드리지 않음 (doc 32).
     private func toggleEngineMode() -> ProcessResult {
         let result = engine.toggleMode()
         let mode = engine.getMode()
         KeyEventTap.currentInputMode = mode
-        if KeyEventTap.toggleKey == .capsLock {
+        if KeyEventTap.toggleKey == .capsLock
+            && CapsLockHIDMonitor.shared.mode != .hidRealLockOn {
             CapsLockSync.setState(mode == .korean)
         }
         return result

--- a/OngeulApp/Sources/InputStateCoordinator.swift
+++ b/OngeulApp/Sources/InputStateCoordinator.swift
@@ -33,34 +33,34 @@ final class InputStateCoordinator: FocusStealModeController {
 
     // MARK: - Private: 모드 변경 + KeyEventTap / CapsLock LED 동기화
 
-    /// 모드 변경 + KeyEventTap 동기화 + CapsLock LED 동기화(doc 30).
+    /// 모드 변경 + KeyEventTap 동기화 + CapsLock LED 동기화.
     ///
     /// - KeyEventTap은 CGEvent 레벨에서 현재 모드를 참조하므로(Control+[ 필터링, keyBuffer 기록),
     ///   모든 모드 변경 시 반드시 동기화해야 한다.
-    /// - `toggleKey == .capsLock`일 때 LED를 모드에 동기화한다(LED ON = 한글).
-    ///   `syncCapsLock: false`는 CapsLock 누름 자체가 모드 변경을 일으킨 경로에서 사용:
-    ///   하드웨어가 이미 LED를 변경했으므로 재설정은 echo만 만들 뿐 (shouldHandle이 걸러내긴 하지만 불필요).
-    /// - 본연 CapsLock 잠금(`hidRealLockOn`) 동안은 사용자가 명시적으로 켠 LED 상태를 존중 —
-    ///   모드 변경이 LED를 건드리지 않는다 (doc 32).
+    /// - LED는 **CGEventTap 폴백 모드에서만** 모드에 동기화 (doc 30 SET 의미론, LED ON = 한글).
+    ///   HID 모드(toggleAuthority/realLockOn)에서는 LED가 *본연 CapsLock 활성 여부* 만을
+    ///   가리킴 (macOS 표준 의미 + 사용자 멘탈 모델 일치). 모드 indicator는 메뉴바 아이콘이 담당.
+    /// - `syncCapsLock: false`는 CapsLock 누름 자체가 모드 변경을 일으킨 경로에서 사용:
+    ///   하드웨어가 이미 LED를 변경했으므로 재설정은 echo만 만듦 (shouldHandle이 걸러내긴 하지만 불필요).
     private func setMode(_ mode: InputMode, syncCapsLock: Bool = true) {
         engine.setMode(mode: mode)
         KeyEventTap.currentInputMode = mode
         if syncCapsLock
             && KeyEventTap.toggleKey == .capsLock
-            && CapsLockHIDMonitor.shared.mode != .hidRealLockOn {
+            && CapsLockHIDMonitor.shared.mode == .cgEventTapAuthority {
             CapsLockSync.setState(mode == .korean)
         }
     }
 
     /// `engine.toggleMode()` 직접 호출 경로(다른 전환 키, IMK fallback, HID 짧은 탭 등).
     /// setMode를 거치지 않으므로 KeyEventTap·CapsLock LED 동기화를 직접 수행.
-    /// 본연 CapsLock 잠금 동안은 LED 건드리지 않음 (doc 32).
+    /// LED 동기화 규칙은 `setMode`와 동일 — HID 모드에선 LED를 건드리지 않음.
     private func toggleEngineMode() -> ProcessResult {
         let result = engine.toggleMode()
         let mode = engine.getMode()
         KeyEventTap.currentInputMode = mode
         if KeyEventTap.toggleKey == .capsLock
-            && CapsLockHIDMonitor.shared.mode != .hidRealLockOn {
+            && CapsLockHIDMonitor.shared.mode == .cgEventTapAuthority {
             CapsLockSync.setState(mode == .korean)
         }
         return result

--- a/OngeulApp/Sources/KeyEventTap.swift
+++ b/OngeulApp/Sources/KeyEventTap.swift
@@ -70,11 +70,11 @@ class KeyEventTap {
                 // keyDown → modifier tap 판정 취소 + 마지막 키 기록
                 if type == .keyDown {
                     // CapsLock 방어 (영문 모드 한정): 영문 통과 경로에서 stale
-                    // maskAlphaShift가 남으면 대문자가 누수된다(이슈 #10). forceOff()의
-                    // IOKit 왕복 지연 동안 keyDown에 남는 비트를 이벤트에서 직접 제거하고
-                    // LED도 OFF로 강제한다. 탭이 IME·앱보다 앞단이므로 IMK 경로와 영문
-                    // 직통 경로가 한 곳에서 모두 보정된다. 이후 keyboardGetUnicodeString도
-                    // 보정된 flags를 사용한다.
+                    // maskAlphaShift가 남으면 대문자가 누수된다(이슈 #10).
+                    // CapsLockSync.setState(false)의 IOKit 왕복 지연 동안 keyDown에 남는
+                    // 비트를 이벤트에서 직접 제거하고 LED도 OFF로 강제한다. 탭이 IME·앱보다
+                    // 앞단이므로 IMK 경로와 영문 직통 경로가 한 곳에서 모두 보정된다.
+                    // 이후 keyboardGetUnicodeString도 보정된 flags를 사용한다.
                     //
                     // 한글 모드에서는 strip하지 않는다: doc 30의 "LED ON = 한글" 의미론상
                     // alpha-lock이 켜져 있는 것이 정상(= LED 인디케이터)이고, 자모는 keycode

--- a/OngeulApp/Sources/KeyEventTap.swift
+++ b/OngeulApp/Sources/KeyEventTap.swift
@@ -80,9 +80,14 @@ class KeyEventTap {
                     // alpha-lock이 켜져 있는 것이 정상(= LED 인디케이터)이고, 자모는 keycode
                     // 기반이라 대문자 누수가 없다. 여기서 끄면 한글 진입 후 첫 키 입력에
                     // LED가 꺼져 인디케이터가 무력화된다.
+                    //
+                    // 본연 CapsLock 잠금(HID 길게-누름으로 진입) 중에도 strip 면제 —
+                    // realLockOn은 영문 모드로 강제되므로 currentInputMode 가드만으로는
+                    // 막히지 않는다. 사용자가 명시적으로 켠 대문자 잠금이 통과돼야 한다 (doc 32).
                     if KeyEventTap.toggleKey == .capsLock
                         && flags.contains(.maskAlphaShift)
-                        && KeyEventTap.currentInputMode == .english {
+                        && KeyEventTap.currentInputMode == .english
+                        && CapsLockHIDMonitor.shared.mode != .hidRealLockOn {
                         CapsLockSync.forceOff()
                         flags.subtract(.maskAlphaShift)
                         event.flags = flags
@@ -175,8 +180,12 @@ class KeyEventTap {
                 // CapsLock은 하드웨어 토글이므로 ToggleDetector를 사용하지 않고
                 // flagsChanged에서 직접 감지하되, 다른 전환 키와 동일한 TOGGLE로 처리한다.
                 // LED는 항상 OFF로 강제하여 CapsLock이 켜지지 않도록 한다.
+                // HID 모니터가 활성이면 (mode != .cgEventTapAuthority) HID가 권위 —
+                // CapsLock 분기는 건너뛴다. HID가 keyDown/keyUp으로 short/long 판정 후
+                // performToggleFromTap (짧은 탭) 또는 performEnterRealCapsLock (길게)을 호출.
                 if type == .flagsChanged && keyCode == Int64(KeyCode.capsLock)
-                    && KeyEventTap.toggleKey == .capsLock {
+                    && KeyEventTap.toggleKey == .capsLock
+                    && CapsLockHIDMonitor.shared.mode == .cgEventTapAuthority {
                     let capsLockOn = flags.contains(.maskAlphaShift)
                     // doc 30 SET 의미론: LED ON=한글, LED OFF=영문. 하드웨어가 이미 상태를
                     // 토글했으므로 SET을 그대로 받아들이고 모드를 그에 맞춘다.

--- a/OngeulApp/Sources/KeyEventTap.swift
+++ b/OngeulApp/Sources/KeyEventTap.swift
@@ -88,7 +88,7 @@ class KeyEventTap {
                         && flags.contains(.maskAlphaShift)
                         && KeyEventTap.currentInputMode == .english
                         && CapsLockHIDMonitor.shared.mode != .hidRealLockOn {
-                        CapsLockSync.forceOff()
+                        CapsLockSync.setState(false)
                         flags.subtract(.maskAlphaShift)
                         event.flags = flags
                     }

--- a/OngeulApp/Sources/OngeulInputController.swift
+++ b/OngeulApp/Sources/OngeulInputController.swift
@@ -1,9 +1,34 @@
 import Cocoa
 import InputMethodKit
 import Carbon
+import IOKit.hid
+import ApplicationServices
 import os.log
 
 private let log = OSLog(subsystem: "io.github.hiking90.inputmethod.Ongeul", category: "input")
+
+// MARK: - System Settings Deep Links
+
+/// 시스템 설정의 Privacy 페인 딥링크.
+/// macOS 13+에서 `x-apple.systempreferences:` URL scheme으로 특정 페인까지 이동.
+private enum PrivacyPane: String {
+    case inputMonitoring = "Privacy_ListenEvent"
+    case accessibility   = "Privacy_Accessibility"
+
+    func open() {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?\(rawValue)") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+}
+
+/// CapsLock HID 모드에 필요한 권한 조회 (프롬프트 트리거 없이 상태만 확인).
+private enum CapsLockPermissions {
+    static var inputMonitoring: Bool {
+        IOHIDCheckAccess(kIOHIDRequestTypeListenEvent) == kIOHIDAccessTypeGranted
+    }
+    static var accessibility: Bool { AXIsProcessTrusted() }
+}
 
 // MARK: - Input Mode IDs
 private enum InputModeID {
@@ -292,9 +317,34 @@ private final class PreferencesPanel {
     @objc private func okClicked(_ sender: Any?) {
         let previousToggleKey = OngeulInputController.toggleKey
         let newToggleKey = toggleKeyTitles[togglePopup.indexOfSelectedItem].0
+        let transitioningToCapsLock = (previousToggleKey != .capsLock && newToggleKey == .capsLock)
+
+        // CapsLock으로 신규 전환 시, 결손 권한이 있으면 안내 시트.
+        // 둘 다 부여돼 있으면 시트 없이 즉시 commit.
+        if transitioningToCapsLock {
+            let missingInput  = !CapsLockPermissions.inputMonitoring
+            let missingAccess = !CapsLockPermissions.accessibility
+            if missingInput || missingAccess {
+                presentCapsLockPermissionAlert(
+                    missingInput: missingInput,
+                    missingAccess: missingAccess,
+                    previousToggleKey: previousToggleKey,
+                    newToggleKey: newToggleKey
+                )
+                return
+            }
+        }
+
+        commitSettings(previousToggleKey: previousToggleKey, newToggleKey: newToggleKey)
+        panel.orderOut(nil)
+    }
+
+    /// 실제 설정 적용 + KeyEventTap 재설치 + HID 모니터 lifecycle.
+    /// okClicked에서 직접 또는 권한 시트 confirm 후 호출.
+    private func commitSettings(previousToggleKey: ToggleKey, newToggleKey: ToggleKey) {
         OngeulInputController.toggleKey = newToggleKey
 
-        // CapsLock 전환 키 변경 시 LED OFF 강제
+        // CapsLock 전환 키 변경 시 LED OFF (잔존 상태 정리)
         if previousToggleKey == .capsLock || newToggleKey == .capsLock {
             CapsLockSync.forceOff()
         }
@@ -316,7 +366,72 @@ private final class PreferencesPanel {
         KeyEventTap.toggleKey = OngeulInputController.toggleKey
         KeyEventTap.shared.install()
 
-        panel.orderOut(nil)
+        // HID 모니터 lifecycle (toggleKey 전이 시)
+        if newToggleKey == .capsLock {
+            do {
+                try CapsLockHIDMonitor.shared.start()
+            } catch {
+                os_log("CapsLockHIDMonitor.start failed: %{public}@",
+                       log: log, type: .error, String(describing: error))
+            }
+        } else if previousToggleKey == .capsLock {
+            CapsLockHIDMonitor.shared.stop()
+        }
+    }
+
+    /// 결손 권한 안내 시트 — 결손 종류에 따라 버튼 동적 구성.
+    /// "설정 열기" 클릭 → 해당 페인 + commit. "취소" → toggleKey 원복.
+    private func presentCapsLockPermissionAlert(
+        missingInput: Bool,
+        missingAccess: Bool,
+        previousToggleKey: ToggleKey,
+        newToggleKey: ToggleKey
+    ) {
+        let alert = NSAlert()
+        alert.messageText = NSLocalizedString("prefs.capsLockSheet.title", comment: "")
+
+        var lines = [NSLocalizedString("prefs.capsLockSheet.intro", comment: "")]
+        if missingInput {
+            lines.append(NSLocalizedString("prefs.capsLockSheet.needInput", comment: ""))
+        }
+        if missingAccess {
+            lines.append(NSLocalizedString("prefs.capsLockSheet.needAccess", comment: ""))
+        }
+        lines.append(NSLocalizedString("prefs.capsLockSheet.restart", comment: ""))
+        alert.informativeText = lines.joined(separator: "\n\n")
+        alert.alertStyle = .informational
+
+        // 결손 종류별 동적 버튼 (가장 첫 추가가 default)
+        var openActions: [(NSApplication.ModalResponse, () -> Void)] = []
+        if missingInput {
+            alert.addButton(withTitle: NSLocalizedString("prefs.capsLockSheet.openInput", comment: ""))
+            let resp = NSApplication.ModalResponse(
+                NSApplication.ModalResponse.alertFirstButtonReturn.rawValue + openActions.count
+            )
+            openActions.append((resp, { PrivacyPane.inputMonitoring.open() }))
+        }
+        if missingAccess {
+            alert.addButton(withTitle: NSLocalizedString("prefs.capsLockSheet.openAccess", comment: ""))
+            let resp = NSApplication.ModalResponse(
+                NSApplication.ModalResponse.alertFirstButtonReturn.rawValue + openActions.count
+            )
+            openActions.append((resp, { PrivacyPane.accessibility.open() }))
+        }
+        alert.addButton(withTitle: NSLocalizedString("prefs.cancel", comment: ""))
+
+        alert.beginSheetModal(for: panel) { [weak self] response in
+            guard let self = self else { return }
+            if let action = openActions.first(where: { $0.0 == response }) {
+                action.1()  // 해당 Privacy 페인 열기
+                self.commitSettings(previousToggleKey: previousToggleKey, newToggleKey: newToggleKey)
+            } else {
+                // 취소 — popup을 이전 값으로 되돌리고 commit 안 함
+                if let idx = self.toggleKeyTitles.firstIndex(where: { $0.0 == previousToggleKey }) {
+                    self.togglePopup.selectItem(at: idx)
+                }
+            }
+            self.panel.orderOut(nil)
+        }
     }
 
     @objc private func cancelClicked(_ sender: Any?) {
@@ -576,6 +691,19 @@ class OngeulInputController: IMKInputController {
             CapsLockSync.forceOff()
         }
 
+        // HID 모니터 lifecycle — toggleKey == .capsLock일 때만 start.
+        // 멱등 (이미 시작돼 있으면 즉시 return). 권한 미부여 등으로 실패하면 로깅만,
+        // CGEventTap 폴백이 자동으로 동작. 메뉴바 헬스 항목이 사용자에게 안내.
+        if Self.toggleKey == .capsLock {
+            CapsLockHIDMonitor.shared.controller = self
+            do {
+                try CapsLockHIDMonitor.shared.start()
+            } catch {
+                os_log("CapsLockHIDMonitor.start failed: %{public}@",
+                       log: log, type: .info, String(describing: error))
+            }
+        }
+
         // Focus-steal correction: 키 입력 시점에 한글 모드였고, English Lock이 아닌 경우만
         // handleKeyDown/deactivateServer에서 keyBuffer를 지우지 않으므로,
         // 정상 타이핑 중 누적된 오래된 키를 제거하여 false positive를 방지한다.
@@ -625,6 +753,17 @@ class OngeulInputController: IMKInputController {
         os_log("menu() called", log: log, type: .default)
         let menu = NSMenu()
 
+        // CapsLock 모드 + HID 모니터 미활성(권한 미부여 등) → 헬스 안내 항목.
+        if Self.toggleKey == .capsLock && !CapsLockHIDMonitor.shared.isStarted {
+            let warningItem = NSMenuItem(
+                title: NSLocalizedString("menu.capsLockNeedsPermission", comment: ""),
+                action: #selector(openCapsLockPermission(_:)),
+                keyEquivalent: "")
+            warningItem.target = self
+            menu.addItem(warningItem)
+            menu.addItem(NSMenuItem.separator())
+        }
+
         let prefsItem = NSMenuItem(
             title: NSLocalizedString("menu.preferences", comment: ""),
             action: #selector(openPreferences(_:)),
@@ -660,6 +799,22 @@ class OngeulInputController: IMKInputController {
     @objc private func openHelp(_ sender: Any?) {
         if let url = URL(string: "https://hiking90.github.io/ongeul/") {
             NSWorkspace.shared.open(url)
+        }
+    }
+
+    /// 메뉴바 헬스 항목 클릭 — 결손 권한 페인 열기 + HID 재시작 시도.
+    @objc private func openCapsLockPermission(_ sender: Any?) {
+        if !CapsLockPermissions.inputMonitoring {
+            PrivacyPane.inputMonitoring.open()
+        } else if !CapsLockPermissions.accessibility {
+            PrivacyPane.accessibility.open()
+        }
+        // 즉시 재시도 — 권한이 이미 부여된 상태일 수도 있고, 부여 직후 사용자가 다시 호출할 수도 있음.
+        do {
+            try CapsLockHIDMonitor.shared.start()
+        } catch {
+            os_log("CapsLockHIDMonitor.start retry failed: %{public}@",
+                   log: log, type: .info, String(describing: error))
         }
     }
 
@@ -761,6 +916,22 @@ class OngeulInputController: IMKInputController {
               )
         else { return }
         applyEffect(effect, to: client)
+    }
+
+    /// CapsLockHIDMonitor의 길게-누름 임계 발화에서 호출 (doc 32).
+    /// 본연 CapsLock 활성화 = 영문 모드 SET + alpha-lock ON.
+    /// macOS native parity: 길게 누르면 항상 *uppercase English* 환경 (현재 모드 무관).
+    func performEnterRealCapsLock() {
+        guard let client: any IMKTextInput = self.client() else { return }
+        // 영문 모드로 SET (현재 모드 무관). setMode가 syncCapsLock=false라 LED 안 건드림.
+        if let effect = coordinator.setModeFromCapsLockPress(
+            korean: false, for: currentBundleId
+        ) {
+            applyEffect(effect, to: client)
+        }
+        // .hidRealLockOn 게이트가 active이므로 doc 30 mode-sync는 LED를 안 건드림 →
+        // 본연 CapsLock LED를 직접 ON으로 set.
+        CapsLockSync.setState(true)
     }
 
     func performVimEscapeFromTap() {

--- a/OngeulApp/Sources/OngeulInputController.swift
+++ b/OngeulApp/Sources/OngeulInputController.swift
@@ -344,8 +344,12 @@ private final class PreferencesPanel {
     private func commitSettings(previousToggleKey: ToggleKey, newToggleKey: ToggleKey) {
         OngeulInputController.toggleKey = newToggleKey
 
-        // CapsLock 전환 키 변경 시 LED OFF (잔존 상태 정리)
-        if previousToggleKey == .capsLock || newToggleKey == .capsLock {
+        // CapsLock 전환 키 변경 시 LED OFF (잔존 상태 정리).
+        // 조건 1: 실제 전이가 일어난 경우만 (toggleKey 변경 없이 OK만 누른 경우는 건드리지 않음).
+        // 조건 2: 본연 CapsLock 잠금 중에는 사용자가 명시적으로 켠 LED 상태 존중 (doc 32 §10 전역 유지).
+        if previousToggleKey != newToggleKey
+            && (previousToggleKey == .capsLock || newToggleKey == .capsLock)
+            && CapsLockHIDMonitor.shared.mode != .hidRealLockOn {
             CapsLockSync.setState(false)
         }
 
@@ -689,8 +693,11 @@ class OngeulInputController: IMKInputController {
         }
 
         // CapsLock이 toggle key일 때 방어적 LED OFF
-        // (다른 앱에서 CapsLock이 켜진 상태로 전환된 경우 대비)
-        if Self.toggleKey == .capsLock && KeyEventTap.shared.isInstalled {
+        // (다른 앱에서 CapsLock이 켜진 상태로 전환된 경우 대비).
+        // 단 본연 CapsLock 잠금 중에는 사용자가 명시적으로 켠 LED 유지 (doc 32 §10 전역).
+        if Self.toggleKey == .capsLock
+            && KeyEventTap.shared.isInstalled
+            && CapsLockHIDMonitor.shared.mode != .hidRealLockOn {
             CapsLockSync.setState(false)
         }
 

--- a/OngeulApp/Sources/OngeulInputController.swift
+++ b/OngeulApp/Sources/OngeulInputController.swift
@@ -945,19 +945,20 @@ class OngeulInputController: IMKInputController {
     }
 
     /// CapsLockHIDMonitor의 본연 CapsLock exit에서 호출 (doc 32, macOS native parity).
-    /// 진입 직전 모드로 복원 + LED를 그 모드에 맞춰 set.
-    /// 예: "한글 → 길게 → 영문+caps → 짧은 탭"이 한국어 + LED ON으로 환원되어 단일 동작 시퀀스 완결.
+    /// 진입 직전 모드로 복원 + LED OFF.
+    /// 예: "한글 → 길게 → 영문+caps → 짧은 탭"이 한국어 + LED OFF로 환원되어 단일 동작 시퀀스 완결.
+    /// LED는 HID 모드에서 *본연 CapsLock 활성 여부* 만을 표현하므로, 복원된 모드와 무관하게 항상 OFF.
     func performExitRealCapsLock(restoreMode: InputMode) {
         guard let client: any IMKTextInput = self.client() else { return }
         let korean = (restoreMode == .korean)
-        // 모드 복원 (setMode가 syncCapsLock=false라 LED는 안 만짐).
+        // 모드 복원 (setMode가 syncCapsLock=false + HID 모드라 LED는 안 만짐).
         if let effect = coordinator.setModeFromCapsLockPress(
             korean: korean, for: currentBundleId
         ) {
             applyEffect(effect, to: client)
         }
-        // 복원된 모드에 맞춰 LED 명시적 동기화 (Korean=ON, English=OFF).
-        CapsLockSync.setState(korean)
+        // LED는 항상 OFF — HID 모드에서 LED = realLockOn 표시 전용.
+        CapsLockSync.setState(false)
     }
 
     func performVimEscapeFromTap() {

--- a/OngeulApp/Sources/OngeulInputController.swift
+++ b/OngeulApp/Sources/OngeulInputController.swift
@@ -346,7 +346,7 @@ private final class PreferencesPanel {
 
         // CapsLock 전환 키 변경 시 LED OFF (잔존 상태 정리)
         if previousToggleKey == .capsLock || newToggleKey == .capsLock {
-            CapsLockSync.forceOff()
+            CapsLockSync.setState(false)
         }
 
         let newLayout: String
@@ -691,7 +691,7 @@ class OngeulInputController: IMKInputController {
         // CapsLock이 toggle key일 때 방어적 LED OFF
         // (다른 앱에서 CapsLock이 켜진 상태로 전환된 경우 대비)
         if Self.toggleKey == .capsLock && KeyEventTap.shared.isInstalled {
-            CapsLockSync.forceOff()
+            CapsLockSync.setState(false)
         }
 
         // HID 모니터 lifecycle — toggleKey == .capsLock일 때만 start.

--- a/OngeulApp/Sources/OngeulInputController.swift
+++ b/OngeulApp/Sources/OngeulInputController.swift
@@ -739,6 +739,14 @@ class OngeulInputController: IMKInputController {
     }
 
     override func deactivateServer(_ sender: Any!) {
+        // 본연 CapsLock(realLockOn) 활성 중 세션 종료(앱 전환/포커스 상실) → 강제 해제.
+        // realLockOn은 영문에 커플링돼 있어 다른 앱으로 끌고 가면 엔진 모드 drift가 생기므로,
+        // 세션 한정으로 종료하고 진입 직전 모드로 엔진을 복원한다 (doc 32 §10).
+        // 복원을 coordinator.deactivate(per-app 저장)보다 *먼저* 수행 → 영문이 저장되는 것 방지.
+        if let restore = CapsLockHIDMonitor.shared.exitRealLockForSessionEnd() {
+            coordinator.restoreModeAfterRealLock(restore)
+        }
+
         focusSteal.cancel()
         // 보류된 selectMode를 지금 호출 — 입력은 끝났으니 stall이 더 이상 의미 없다.
         flushSelectMode()

--- a/OngeulApp/Sources/OngeulInputController.swift
+++ b/OngeulApp/Sources/OngeulInputController.swift
@@ -368,6 +368,9 @@ private final class PreferencesPanel {
 
         // HID 모니터 lifecycle (toggleKey 전이 시)
         if newToggleKey == .capsLock {
+            // controller 주입을 start() 이전에 — race 방지 (activateServer 호출 전이라도
+            // 사용자가 prefs 닫고 즉시 CapsLock 누르면 HID 콜백이 fire될 수 있음).
+            CapsLockHIDMonitor.shared.controller = KeyEventTap.activeController
             do {
                 try CapsLockHIDMonitor.shared.start()
             } catch {
@@ -932,6 +935,22 @@ class OngeulInputController: IMKInputController {
         // .hidRealLockOn 게이트가 active이므로 doc 30 mode-sync는 LED를 안 건드림 →
         // 본연 CapsLock LED를 직접 ON으로 set.
         CapsLockSync.setState(true)
+    }
+
+    /// CapsLockHIDMonitor의 본연 CapsLock exit에서 호출 (doc 32, macOS native parity).
+    /// 진입 직전 모드로 복원 + LED를 그 모드에 맞춰 set.
+    /// 예: "한글 → 길게 → 영문+caps → 짧은 탭"이 한국어 + LED ON으로 환원되어 단일 동작 시퀀스 완결.
+    func performExitRealCapsLock(restoreMode: InputMode) {
+        guard let client: any IMKTextInput = self.client() else { return }
+        let korean = (restoreMode == .korean)
+        // 모드 복원 (setMode가 syncCapsLock=false라 LED는 안 만짐).
+        if let effect = coordinator.setModeFromCapsLockPress(
+            korean: korean, for: currentBundleId
+        ) {
+            applyEffect(effect, to: client)
+        }
+        // 복원된 모드에 맞춰 LED 명시적 동기화 (Korean=ON, English=OFF).
+        CapsLockSync.setState(korean)
     }
 
     func performVimEscapeFromTap() {

--- a/design/32-hid-capslock-press-duration.md
+++ b/design/32-hid-capslock-press-duration.md
@@ -297,9 +297,9 @@ if type == .flagsChanged && keyCode == Int64(KeyCode.capsLock)
 if KeyEventTap.toggleKey == .capsLock
     && flags.contains(.maskAlphaShift) {
     if CapsLockHIDMonitor.shared.mode == .hidRealLockOn {
-        // 본연 CapsLock ON 중에는 strip·forceOff 면제 → 대문자 통과
+        // 본연 CapsLock ON 중에는 strip·setState 호출 자체를 면제 → 대문자 통과
     } else {
-        CapsLockSync.forceOff()
+        CapsLockSync.setState(false)
         flags.subtract(.maskAlphaShift)
         event.flags = flags
     }
@@ -519,6 +519,7 @@ NSWorkspace.shared.open(URL(string:
 4. **`NSInputMonitoringUsageDescription` IMK 적용성**: IMK 앱은 시스템 launch 백그라운드 프로세스라 표준 TCC 프롬프트 비신뢰. 사용자 매뉴얼(우리 시트) + 딥링크로 우회.
 5. **다중 키보드 동시**: 두 키보드의 CapsLock 거의 동시 누름 시 상태머신 일관성 검증.
 6. **이슈 #10과의 연결**: 본 doc 채택 후 #10 환경 원인(SokIM 공존 / Tahoe race) 중 무엇이 실제였는지 사후 회고 필요. PR #11으로 충분히 닫혔는지, 본 doc 구현 후에야 닫히는지 분리 검증.
+7. **`CapsLockSync.expectedState` 단일 변수 덮어쓰기 race**: 빠른 연속 `setState()` 호출(예: `loadLayout` 직후 `activateApp` 같은 init 시퀀스, 또는 `enterRealCapsLock`의 `setState(true)`가 직전 `setState(false)` echo 도착 전에 일어나는 경우) 시 이전 `expectedState`가 덮어써져 *#1의 echo가 #2의 expected와 불일치 → `shouldHandle()`이 사용자 입력으로 오인 → spurious 토글* 가능. doc 30의 100ms 타임아웃은 echo 미도착만 처리하고 덮어쓰기는 막지 못함. 실제 발생 조건은 5ms 내 두 번의 mode-set이라 좁지만 0은 아님. 견고한 해결은 `expectedState`를 *큐* 구조로 두고 echo 도착 시 oldest와 매칭하는 것 — 복잡도 증가로 doc 32 범위 외, 후속 RFC. 스파이크 측정 항목 #7(OS 부하 민감성)에서 함께 확인 가치.
 
 ---
 

--- a/design/32-hid-capslock-press-duration.md
+++ b/design/32-hid-capslock-press-duration.md
@@ -1,6 +1,6 @@
 # 32. HID 기반 CapsLock 입력 처리 (짧게 / 길게 분리)
 
-> **상태**: 설계 v2 — Phase 1.5 스파이크 결과 대기
+> **상태**: 설계 v2 — **스파이크 완료, 시나리오 A 확정 (2026-05-21)**. PR #14 머지 ready.
 
 ## Context
 
@@ -42,6 +42,16 @@
 | 상태/LED 자체가 외부 stomp에 의해 즉시 되돌려짐 | **C** | 이 doc 보류. (B) 기능 미지원 유지 — HID는 짧은 탭 신뢰성·#10 race 차단 용도로만 한정 채택할지 별도 판단 |
 
 본 문서 이하 내용은 결과 **A** 가정. **B**가 되면 § 기존 코드 통합 절의 일부만 교체(영문 통과 경로에 대문자 합성). **C**면 doc 폐기.
+
+### ✅ 스파이크 결과 (2026-05-21)
+
+end-to-end 시퀀스 *한국어 모드 → 길게 누름 → 영문 + Caps Lock ON → 대문자 영문 타이핑 정상 → 짧은 탭 → 한국어 복원 + LED OFF* 가 사용자 환경에서 모두 확인됨. 핵심 단언:
+
+- **`IOHIDSetModifierLockState(handle, kIOHIDCapsLockState, true)` 호출 후, 실제 keyDown들이 alpha-shift 적용된 대문자 문자로 앱에 전달됨** → **시나리오 A 확정**.
+- macOS의 OS-level stomp(SokIM이 11회 반복으로 회피하던 Sonoma+ bubble) 현상은 우리 환경에선 *관찰되지 않음* — 단일 `setState(true)` 호출로 상태 유지됨.
+- macOS native parity 약속(*"한국어 → 길게 → 영문대문자 → 짧은 탭 → 한국어"가 단일 시퀀스*)이 `modeBeforeRealLock` 복원 로직으로 정확히 동작.
+
+→ 본 doc의 핵심 설계 가정이 모두 입증. PR #14의 스파이크 gate 해제, 머지 ready.
 
 ## 목표
 

--- a/design/32-hid-capslock-press-duration.md
+++ b/design/32-hid-capslock-press-duration.md
@@ -85,7 +85,7 @@ doc 32는 doc 30을 *대체하지 않는다*. 분업:
 | **CGEventTap CapsLock 분기의 게이팅(HID 활성 시 우회)** | `KeyEventTap` 수정 | **doc 32** |
 | TCC UX 시트(권한 안내·딥링크) | `OngeulInputController` 설정 패널 | **doc 32** |
 
-doc 30이 정의한 SET 의미론(*"LED ON = 한글"*)은 **짧은 탭 분기에서만 적용**되고, 길게-누름은 SET 의미론 외부의 별도 분기(=본연 CapsLock)로 다룬다.
+doc 30이 정의한 SET 의미론(*"LED ON = 한글"*)은 **CGEventTap 폴백 모드(HID 미활성)에서만 유효**하고, HID 모드(hidToggleAuthority/hidRealLockOn)에서는 **LED가 *본연 CapsLock 활성 여부* 만을 표현**한다. 이유: HID 모드에선 길게-누름이 진짜 Caps Lock을 켤 수 있으므로 LED가 두 의미를 가지면(Korean indicator vs Caps Lock 활성) 사용자에게 ambiguous. macOS 표준 의미("LED ON = 대문자 잠금")와 정합하도록 *LED = realLockOn 표시 전용*으로 통일. 모드 indicator는 메뉴바 아이콘이 담당.
 
 ## 옵트인 게이팅
 
@@ -145,7 +145,7 @@ enum CapsLockMode {
 |---|---|
 | `KeyEventTap` flagsChanged CapsLock 분기 (doc 30) | `current == .cgEventTapAuthority` 일 때만 실행 |
 | `KeyEventTap` keyDown `.maskAlphaShift` strip ([PR #11](https://github.com/hiking90/ongeul/pull/11)) | `current != .hidRealLockOn` 일 때만 실행 (본연 잠금 중엔 대문자 통과) |
-| `InputStateCoordinator.setMode` LED 동기화 (doc 30) | `current != .hidRealLockOn` 일 때만 LED set (본연 잠금 중엔 사용자 상태 존중) |
+| `InputStateCoordinator.setMode` LED 동기화 (doc 30) | `current == .cgEventTapAuthority` 일 때만 LED set. HID 모드(toggleAuthority/realLockOn)에선 LED 미동기화 — LED는 realLockOn 전용 indicator |
 | `CapsLockHIDMonitor` | 자기 자신이 상태 변경의 권위. 시작/정지/타이머 발화/short tap/long press 시 `current`를 변경 |
 
 상태 전이:
@@ -173,7 +173,7 @@ hidRealLockOn        ──HID fail/stop──▶     cgEventTapAuthority  (+ LE
         │     │                                       │
         │     ├─ HID: keyUp(0x39) (timer 아직)        │
         │     │     → coordinator.toggleMode()        │
-        │     │       doc 30이 LED 동기화             │
+        │     │       (HID 모드: LED 미동기화 — 항상 OFF) │
         │     │       복귀 ─▶ [CapsOFF]                │
         │     │                                       │
         │     └─ Timer 발화 (keyDown 유지 중)         │
@@ -191,12 +191,14 @@ hidRealLockOn        ──HID fail/stop──▶     cgEventTapAuthority  (+ LE
         └─────────────────────────────────────────────┘
 ```
 
-| 현재 | 입력 | 동작 | 다음 |
+| 현재 | 입력 | 동작 | 다음 LED |
 |---|---|---|---|
-| CapsOFF | 짧은 탭 (< 800ms) | toggleMode + doc 30 mode-sync로 LED 정합 | CapsOFF (또는 LED=ON if 한글) |
-| CapsOFF | 길게 (≥ 800ms) | `setState(true)` + 토글 억제 + mode=`hidRealLockOn` | CapsON |
-| CapsON | 짧은 탭 | `setState(false)` + mode=`hidToggleAuthority` + 토글 안 함 | CapsOFF |
-| CapsON | 길게 | 짧은 탭과 동일 — `setState(false)` + 종료 | CapsOFF |
+| CapsOFF | 짧은 탭 (< 800ms) | toggleMode (HID 모드라 LED 미동기화 — 모드만 변경) | OFF |
+| CapsOFF | 길게 (≥ 800ms) | `setState(true)` + 토글 억제 + mode=`hidRealLockOn` | **ON** (realLockOn 표시) |
+| CapsON | 짧은 탭 | exitRealCapsLock — `setState(false)` + mode=`hidToggleAuthority` + 진입직전 모드 복원, 토글 안 함 | OFF |
+| CapsON | 길게 | 짧은 탭과 동일 — `setState(false)` + 종료 | OFF |
+
+> **LED 의미**: HID 모드에서 LED는 *본연 CapsLock 활성 여부* 만 표현(=`hidRealLockOn` 상태). macOS 표준 의미와 일치, 사용자 혼란 방지. 모드 표시는 메뉴바 아이콘이 담당.
 
 ## 임계값 — 800ms 하드코딩
 
@@ -438,10 +440,10 @@ NSWorkspace.shared.open(URL(string:
 
 | # | 상황 | 결과 |
 |---|---|---|
-| 1 | OFF 상태에서 짧게 탭 (전환 키=CapsLock, HID 정상) | HID keyDown → 타이머 시작 + `setState(false)`. keyUp이 임계 전 → `toggleMode()`. doc 30 mode-sync가 LED를 모드에 정합. PR #11 strip 정상. |
+| 1 | OFF 상태에서 짧게 탭 (전환 키=CapsLock, HID 정상) | HID keyDown → 타이머 시작 + `setState(false)`. keyUp이 임계 전 → `toggleMode()` → 엔진 모드만 토글 (HID 모드에선 LED 미동기화 — LED는 OFF 유지). PR #11 strip 정상. |
 | 2 | OFF 상태에서 800ms 이상 보유 | 타이머 발화 → `mode=.hidRealLockOn` + `setState(true)`. 한/영 토글 안 함. 이후 keyDown들은 strip 면제 → 대문자가 앱에 전달 (스파이크 결과 A 가정). |
 | 3 | ON 상태에서 짧게 탭 | `mode == .hidRealLockOn` 확인 → `exitRealCapsLock()` → `setState(false)` + `mode=.hidToggleAuthority`. 토글 안 함. |
-| 4 | ON 상태에서 한/영 모드가 다른 경로(우커맨드 탭 등)로 변경 | `setMode`가 `mode == .hidRealLockOn` 가드에 막혀 LED 안 건드림 — 사용자가 켠 본연 CapsLock 유지. |
+| 4 | ON 상태에서 한/영 모드가 다른 경로(우커맨드 탭 등)로 변경 | `setMode`가 HID 모드 가드에 막혀 LED 안 건드림 — 사용자가 켠 본연 CapsLock LED 유지. |
 | 5 | 권한 미부여 | `start()` `kIOReturnNotPermitted` throws → `mode=.cgEventTapAuthority` 유지 → doc 30 CGEventTap 경로. 메뉴바 배너 + 딥링크. (B) 미지원. |
 | 6 | SokIM과 공존 | HID open 성공(비-seize). 양측 상태 set 시도가 겹치면 race — `hidRealLockOn` 시점에만 set ON하므로 일상 짧은 탭은 안전. 사용자 안내 권고. |
 | 7 | 절전 → 복귀 | `didWakeNotification` → `CapsLockHIDMonitor.restart()`. |

--- a/design/32-hid-capslock-press-duration.md
+++ b/design/32-hid-capslock-press-duration.md
@@ -468,6 +468,7 @@ NSWorkspace.shared.open(URL(string:
 4. **`CGEventSourceFlagsState(.combinedSessionState).contains(.maskAlphaShift)`**: 즉시 true?
 5. **stomp 검증**: 호출 후 1~2초 관찰. OS가 외부 요인으로 false로 되돌리는가? SokIM 11회 반복 패턴의 현재 OS 유효성.
 6. **HID 콜백이 시스템 Caps Lock 지연과 무관하게 도착하는가?** `hidutil property --set CapsLockDelayOverride 250` 설정 후 짧은 탭 — HID 모니터가 받는가? (받는다면 사용자에게 `hidutil` 안내 불필요화 가능.)
+7. **`CapsLockSync.shouldHandle()` 100ms 타임아웃의 OS 부하 민감성**: 정상 환경에선 `IOHIDSetModifierLockState` 후 echo `flagsChanged`가 1~10ms 내 도착해 `expectedState` 가드가 정확히 동작하지만, 무거운 VM/CI/저성능 환경에서 echo가 100ms 이상 지연되면 가드가 만료되어 echo를 *사용자 입력*으로 오인 → spurious 토글 발생. 측정: 인위적 부하(`stress-ng -c N` 등) 상태에서 mode 변경 → echo 도착 시간 분포 측정. 디폴트 100ms로 부족하면 doc 30·doc 32의 `expectedStateTimeout`을 상향 검토 (단, 사용자가 임계 안에 CapsLock을 누를 물리적 한계와 균형).
 
 ### 예상 시간
 

--- a/design/32-hid-capslock-press-duration.md
+++ b/design/32-hid-capslock-press-duration.md
@@ -516,7 +516,7 @@ NSWorkspace.shared.open(URL(string:
 1. **`hidRealLockOn`의 영속성**: 앱 전환 시 전역 ON 유지로 결정([§ 동작 시나리오](#동작-시나리오) #10). macOS Caps Lock 의미론과 일치하며 사용자 멘탈 모델과도 합치. *전역* 결정으로 doc 32 확정.
 2. **HID 콜백 침묵 자동 복구**: SokIM `restartIfIdle()` 패턴 도입 여부. idle 임계와 false positive 검토.
 3. **`IOHIDSetModifierLockState` Tahoe 동작 차이**: 스파이크에서 정밀화.
-4. **`NSInputMonitoringUsageDescription` IMK 적용성**: IMK 앱은 시스템 launch 백그라운드 프로세스라 표준 TCC 프롬프트 비신뢰. 사용자 매뉴얼(우리 시트) + 딥링크로 우회.
+4. **`NSInputMonitoringUsageDescription` IMK 적용성**: ~~미검증~~ → **검증됨 (필수)**. 이 키가 Info.plist에 없으면 `IOHIDManagerOpen` 호출이 TCC 리스트에 앱을 *등록조차 시키지 못함* (시스템 설정 → 입력 모니터링에 앱이 안 보임). on-demand 등록 흐름이 무력화되어 사용자가 권한 부여 자체를 할 수 없는 막다른 상태가 됨. **현재 [`OngeulApp/Resources/Info.plist`](../OngeulApp/Resources/Info.plist)에 `NSAccessibilityUsageDescription`과 함께 추가됨**. IMK 앱이 표준 TCC 프롬프트를 띄우지 못하는 한계는 여전 → 우리 시트 + 딥링크 경로 유지.
 5. **다중 키보드 동시**: 두 키보드의 CapsLock 거의 동시 누름 시 상태머신 일관성 검증.
 6. **이슈 #10과의 연결**: 본 doc 채택 후 #10 환경 원인(SokIM 공존 / Tahoe race) 중 무엇이 실제였는지 사후 회고 필요. PR #11으로 충분히 닫혔는지, 본 doc 구현 후에야 닫히는지 분리 검증.
 7. **`CapsLockSync.expectedState` 단일 변수 덮어쓰기 race**: 빠른 연속 `setState()` 호출(예: `loadLayout` 직후 `activateApp` 같은 init 시퀀스, 또는 `enterRealCapsLock`의 `setState(true)`가 직전 `setState(false)` echo 도착 전에 일어나는 경우) 시 이전 `expectedState`가 덮어써져 *#1의 echo가 #2의 expected와 불일치 → `shouldHandle()`이 사용자 입력으로 오인 → spurious 토글* 가능. doc 30의 100ms 타임아웃은 echo 미도착만 처리하고 덮어쓰기는 막지 못함. 실제 발생 조건은 5ms 내 두 번의 mode-set이라 좁지만 0은 아님. 견고한 해결은 `expectedState`를 *큐* 구조로 두고 echo 도착 시 oldest와 매칭하는 것 — 복잡도 증가로 doc 32 범위 외, 후속 RFC. 스파이크 측정 항목 #7(OS 부하 민감성)에서 함께 확인 가치.

--- a/design/32-hid-capslock-press-duration.md
+++ b/design/32-hid-capslock-press-duration.md
@@ -459,7 +459,7 @@ NSWorkspace.shared.open(URL(string:
 | 7 | 절전 → 복귀 | `didWakeNotification` → `CapsLockHIDMonitor.restart()`. |
 | 8 | 전환 키를 CapsLock→우커맨드로 변경 | `okClicked`에서 `stop()` + `CapsLockSync.reset()` + LED OFF. TCC 권한은 시스템에 남되 모니터는 정지. |
 | 9 | 우커맨드→CapsLock 변경 | UX 시트 (권한 결손 시) 또는 즉시 활성 (권한 둘 다 있음) → `start()`. |
-| 10 | 본연 CapsLock ON 상태에서 IME 전환(앱 변경) | `mode=.hidRealLockOn` 그대로 유지 (전역). macOS Caps Lock 의미론 매칭. |
+| 10 | 본연 CapsLock ON 상태에서 IME 전환(앱 변경) | `deactivateServer`에서 `exitRealLockForSessionEnd()` 호출 → realLockOn 해제 + 진입 직전 모드로 엔진 복원 + LED OFF. **세션 한정**(전역 아님) — 아래 § 미해결 #1 참조. |
 | 11 | 암호 필드 진입 (Secure Input) | doc 30 시나리오와 동일. HID 콜백은 계속 들어오지만 `controller.isCurrentAppLocked`/`IsSecureEventInputEnabled` 체크로 coordinator 호출 억제. |
 | 12 | `hidRealLockOn` 상태에서 사용자가 권한 회수 | HID 콜백 중단. 헬스체크가 회수를 탐지하면 `CapsLockSync.setState(false)` + `mode=.cgEventTapAuthority`로 환원. |
 
@@ -525,13 +525,15 @@ NSWorkspace.shared.open(URL(string:
 
 ## 미해결 / 후속 검토
 
-1. **`hidRealLockOn`의 영속성**: 앱 전환 시 전역 ON 유지로 결정([§ 동작 시나리오](#동작-시나리오) #10). macOS Caps Lock 의미론과 일치하며 사용자 멘탈 모델과도 합치. *전역* 결정으로 doc 32 확정.
+1. **`hidRealLockOn`의 영속성**: ~~전역~~ → **세션 한정으로 수정** (앱 전환/포커스 상실 시 `deactivateServer`의 `exitRealLockForSessionEnd()`가 자동 해제 + 진입 직전 모드 복원). 이유: 진짜 macOS Caps Lock은 입력 소스와 *직교*(어떤 소스든 대문자만)라 전역이 자연스럽지만, 우리 realLockOn은 **영문 모드 강제와 커플링**돼 있어 전역 유지 시 per-app 모드 복원이 엔진을 다른 모드로 바꿔 *LED는 ON(caps)인데 한글이 입력되는 drift*가 발생. transient 의도("지금 대문자")에도 세션 한정이 부합하며, caps episode가 진입 직전 상태로 완전히 환원되어 끝남. (트레이드오프: 진짜 macOS Caps Lock과 달리 앱 전환을 가로질러 유지되지 않음 — 모드 커플링 때문에 수용.)
 2. **HID 콜백 침묵 자동 복구**: SokIM `restartIfIdle()` 패턴 도입 여부. idle 임계와 false positive 검토.
 3. **`IOHIDSetModifierLockState` Tahoe 동작 차이**: 스파이크에서 정밀화.
 4. **`NSInputMonitoringUsageDescription` IMK 적용성**: ~~미검증~~ → **검증됨 (필수)**. 이 키가 Info.plist에 없으면 `IOHIDManagerOpen` 호출이 TCC 리스트에 앱을 *등록조차 시키지 못함* (시스템 설정 → 입력 모니터링에 앱이 안 보임). on-demand 등록 흐름이 무력화되어 사용자가 권한 부여 자체를 할 수 없는 막다른 상태가 됨. **현재 [`OngeulApp/Resources/Info.plist`](../OngeulApp/Resources/Info.plist)에 `NSAccessibilityUsageDescription`과 함께 추가됨**. IMK 앱이 표준 TCC 프롬프트를 띄우지 못하는 한계는 여전 → 우리 시트 + 딥링크 경로 유지.
 5. **다중 키보드 동시**: 두 키보드의 CapsLock 거의 동시 누름 시 상태머신 일관성 검증.
 6. **이슈 #10과의 연결**: 본 doc 채택 후 #10 환경 원인(SokIM 공존 / Tahoe race) 중 무엇이 실제였는지 사후 회고 필요. PR #11으로 충분히 닫혔는지, 본 doc 구현 후에야 닫히는지 분리 검증.
 7. **`CapsLockSync.expectedState` 단일 변수 덮어쓰기 race**: 빠른 연속 `setState()` 호출(예: `loadLayout` 직후 `activateApp` 같은 init 시퀀스, 또는 `enterRealCapsLock`의 `setState(true)`가 직전 `setState(false)` echo 도착 전에 일어나는 경우) 시 이전 `expectedState`가 덮어써져 *#1의 echo가 #2의 expected와 불일치 → `shouldHandle()`이 사용자 입력으로 오인 → spurious 토글* 가능. doc 30의 100ms 타임아웃은 echo 미도착만 처리하고 덮어쓰기는 막지 못함. 실제 발생 조건은 5ms 내 두 번의 mode-set이라 좁지만 0은 아님. 견고한 해결은 `expectedState`를 *큐* 구조로 두고 echo 도착 시 oldest와 매칭하는 것 — 복잡도 증가로 doc 32 범위 외, 후속 RFC. 스파이크 측정 항목 #7(OS 부하 민감성)에서 함께 확인 가치.
+8. **alpha-lock 외부 desync 미감지**: 본 설계는 `setState`로 alpha-lock을 set-and-forget. realLockOn 중 다른 앱/시스템이 alpha-lock을 false로 바꾸면 *LED ON인데 소문자* 불일치. 외부 actor가 드물고 헬스 폴링은 과하므로 알려진 한계로 둠. 불변식 `alpha-lock == true ⟺ mode == .hidRealLockOn`은 우리 코드 내부에서만 보장.
+9. **on/off 비대칭 (의도적)**: ON은 800ms 임계 게이트, OFF는 realLockOn 중 *아무 press*(짧게/길게 무관 — `onKeyDown`이 realLockOn에서 즉시 early-return하고 `onKeyUp`이 exit). 즉 caps를 켠 뒤엔 길게 눌러도 그냥 꺼짐. macOS의 "caps on 상태에서 탭하면 끔"과 부합하나, 사용자가 "길게 눌러 유지" 같은 걸 기대하면 어긋남 — 문서/도움말에 명시 가치.
 
 ---
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -47,21 +47,23 @@ mkdir -p "$INSTALL_DIR"
 rm -rf "$INSTALL_DIR/Ongeul.app"
 cp -r "$APP_BUNDLE" "$INSTALL_DIR/"
 
-# ── 5. 손쉬운 사용(Accessibility) 권한 설정 ──
+# ── 5. TCC 권한 설정 (손쉬운 사용 + 입력 모니터링) ──
 
 BUNDLE_ID="io.github.hiking90.inputmethod.Ongeul"
 TCC_DB="/Library/Application Support/com.apple.TCC/TCC.db"
 INSTALLED_APP="$INSTALL_DIR/Ongeul.app"
 
-echo "=== Setting up Accessibility permission ==="
+echo "=== Setting up TCC permissions ==="
 
-# 앱이 재서명되면 기존 TCC 항목이 무효화되므로 리셋
+# 앱이 재서명되면 기존 TCC 항목이 무효화되므로 리셋.
+#  - Accessibility: 항상 필요 (CGEventTap)
+#  - ListenEvent (입력 모니터링): CapsLock 전환 키 사용 시 필요 (HID 모니터)
 sudo tccutil reset Accessibility "$BUNDLE_ID" 2>/dev/null || true
+sudo tccutil reset ListenEvent   "$BUNDLE_ID" 2>/dev/null || true
 
 SIP_STATUS=$(csrutil status 2>&1)
 if echo "$SIP_STATUS" | grep -q "disabled"; then
-    # SIP 비활성화 상태: sqlite3로 자동 권한 부여
-    # 서명된 앱에서 csreq blob 생성
+    # SIP 비활성화 상태: sqlite3로 자동 권한 부여 (서명된 앱의 csreq 사용)
     CSREQ_VALUE="NULL"
     REQ_STR=$(codesign -d -r- "$INSTALLED_APP" 2>&1 | awk -F ' => ' '/designated/{print $2}')
     if [ -n "$REQ_STR" ]; then
@@ -73,18 +75,24 @@ if echo "$SIP_STATUS" | grep -q "disabled"; then
         rm -f "$CSREQ_TMP"
     fi
 
-    sudo sqlite3 "$TCC_DB" \
-        "INSERT OR REPLACE INTO access (service, client, client_type, auth_value, auth_reason, auth_version, csreq, policy_id, indirect_object_identifier_type, indirect_object_identifier, indirect_object_code_identity, flags, last_modified) VALUES ('kTCCServiceAccessibility', '${BUNDLE_ID}', 0, 2, 3, 1, ${CSREQ_VALUE}, NULL, NULL, 'UNUSED', NULL, 0, CAST(strftime('%s','now') AS INTEGER));"
+    # 두 서비스 동시 부여 — 동일한 csreq, 동일한 INSERT 패턴.
+    for SERVICE in kTCCServiceAccessibility kTCCServiceListenEvent; do
+        sudo sqlite3 "$TCC_DB" \
+            "INSERT OR REPLACE INTO access (service, client, client_type, auth_value, auth_reason, auth_version, csreq, policy_id, indirect_object_identifier_type, indirect_object_identifier, indirect_object_code_identity, flags, last_modified) VALUES ('${SERVICE}', '${BUNDLE_ID}', 0, 2, 3, 1, ${CSREQ_VALUE}, NULL, NULL, 'UNUSED', NULL, 0, CAST(strftime('%s','now') AS INTEGER));"
+    done
 
-    # tccd 재시작으로 변경사항 반영
+    # tccd 재시작으로 변경사항 반영 (두 서비스 모두 적용)
     sudo killall tccd 2>/dev/null || true
 
-    echo "    Accessibility 권한이 자동으로 부여되었습니다."
+    echo "    손쉬운 사용 + 입력 모니터링 권한이 자동으로 부여되었습니다."
 else
     # SIP 활성화 상태: 수동 설정 안내
     echo "    SIP이 활성화되어 있어 자동 권한 부여가 불가합니다."
-    echo "    시스템 설정 → 개인 정보 보호 및 보안 → 손쉬운 사용 에서"
-    echo "    Ongeul을 추가하고 활성화해 주세요."
+    echo "    시스템 설정 → 개인 정보 보호 및 보안 에서 다음을 추가/활성화해 주세요:"
+    echo "      • 손쉬운 사용 (CGEventTap 사용 — 필수)"
+    echo "      • 입력 모니터링 (CapsLock 전환 키 사용 시 필요 — HID 모니터)"
+    echo "    참고: 입력 모니터링은 Ongeul이 CapsLock 모드로 첫 진입할 때까지"
+    echo "    리스트에 보이지 않을 수 있습니다 (전환 키를 CapsLock으로 바꾼 직후 표시됨)."
 fi
 echo ""
 


### PR DESCRIPTION
## Summary

Stacked on [Phase 1 PR #13](https://github.com/hiking90/ongeul/pull/13). Implements [`design/32-hid-capslock-press-duration.md`](design/32-hid-capslock-press-duration.md): **macOS-native parity** for the CapsLock toggle key — tap = language toggle, press-and-hold (≥800ms) = real Caps Lock uppercase. Apple's own Input Sources UI text says *"Use the Caps Lock key to switch to and from U.S. **Press and hold to enable typing in all uppercase**."* — this PR brings Ongeul in line with that decade-old platform behavior.

Opt-in: HID monitor activates only when `toggleKey == .capsLock`. Other toggle key users see zero behavior change and no new permission requirement.

## ⚠ Spike gate — merge only after Phase 1.5 spike

The `performEnterRealCapsLock()` path calls `CapsLockSync.setState(true)` assuming follow-up `keyDown`s reach apps with `.maskAlphaShift` applied. [SokIM's source](https://github.com/kiding/SokIM/blob/main/SokIM/Helpers.swift) suggests this may not be reliable on Sonoma+ — they keep system state always `false` and synthesize uppercase via their own engine with explicit *"Sonoma 이후 커서 밑에 생기는 '버블'/HUD/Indicator/Accessory 방지"* stomp counter-handling.

**Before merge, run [doc 32 § 스파이크 계획](design/32-hid-capslock-press-duration.md#스파이크-계획)** (7 measurement items, ~5–8h including Tahoe VM setup):
- **Scenario A** (apps receive uppercase) → merge as-is
- **Scenario B** (state set but apps lowercase) → add small follow-up: English-passthrough uppercase synthesis (HID monitor remains correct)
- **Scenario C** (OS stomps state) → drop long-press support; HID still useful for short-tap reliability

Either way, Phase 1's keyDown strip + Phase 1's SET semantics remain valid — Phase 2 is purely additive for long-press support.

## Commits on this branch (4 new on top of Phase 1)

| Commit | Content |
|---|---|
| `5733d8f` | Phase 2 core — `CapsLockHIDMonitor.swift` (HID monitor + `CapsLockMode` enum + 800ms timer + state machine); KeyEventTap gating; InputStateCoordinator LED-sync gating on `mode != .hidRealLockOn`; TCC sheet with `IOHIDCheckAccess` + `AXIsProcessTrusted` gating (sheet only shown when actually missing); menu-bar health item; `Privacy_ListenEvent` / `Privacy_Accessibility` deep links; Localizable strings |
| `2b1c49a` | **Re-review fixes (items 2 + 4)**: `exitRealCapsLock` now restores `modeBeforeRealLock` for full macOS-native single-action exit; `commitSettings` injects controller into HID monitor before start (race fix) |
| `b7e1a18` | Re-review item 6: doc 32 spike measurement #7 — `expectedState` 100ms timeout sensitivity to OS load |
| `6430ad5` | Re-review item 5: migrates remaining 3 `CapsLockSync.forceOff()` callers to `setState(false)`, drops the alias. Behaviorally identical |

## Architecture highlights

`CapsLockMode` single enum drives 3 modules:

```
.cgEventTapAuthority   — HID inactive (fallback): doc 30 path runs
.hidToggleAuthority    — HID active, short-tap mode
.hidRealLockOn         — long-press engaged real Caps Lock
```

- `KeyEventTap` flagsChanged CapsLock branch (Phase 1) gated on `mode == .cgEventTapAuthority`
- `KeyEventTap` keyDown `.maskAlphaShift` strip (PR #11/Phase 1) gated on `mode != .hidRealLockOn`
- `InputStateCoordinator.setMode`/`toggleEngineMode` LED sync gated on `mode != .hidRealLockOn`

State machine:

```
.cgEventTapAuthority  ──HID start success──▶  .hidToggleAuthority
.hidToggleAuthority   ──HID stop/fail──▶      .cgEventTapAuthority
.hidToggleAuthority   ──long press fires──▶   .hidRealLockOn (save modeBeforeRealLock)
.hidRealLockOn        ──next short tap──▶     .hidToggleAuthority (restore prev mode)
.hidRealLockOn        ──HID stop/fail──▶      .cgEventTapAuthority (+ LED off)
```

The exit transition restoring `modeBeforeRealLock` is what gives single-action exit — *"한글 → 길게 → English+caps → 짧은 탭 → 한글 (caps off)"* — matching macOS native.

## Permission UX

When user transitions to `toggleKey == .capsLock` in preferences, the sheet appears **only if** `IOHIDCheckAccess(kIOHIDRequestTypeListenEvent) != kIOHIDAccessTypeGranted` or `!AXIsProcessTrusted()`. Buttons are dynamically composed based on which permissions are missing. Health menu item appears when toggleKey is CapsLock and HID can't start.

## Distribution caveat

Ad-hoc-signed builds will see the Input Monitoring permission silently revoked on each update (TCC binds to unstable designated requirement). Doc 50 (Developer ID + notarization) is recommended in tandem for general availability — see [§ 서명·공증 선결조건](design/32-hid-capslock-press-duration.md#서명공증-선결조건-phase-4-의존성) in doc 32.

For dev/repro VMs only, [scripts/install.sh](scripts/install.sh)'s SIP-off TCC auto-grant trick can be extended to `kTCCServiceListenEvent` as a follow-up (not in this PR).

## Verification

`swiftc -typecheck` of all sources passes with **zero warnings** on this branch. Runtime verification is gated on the spike above.

## Stacked PR — merge order

1. PR #11 (keyDown strip) — independent, low-risk
2. PR #13 (Phase 1 — doc 30 SET semantics) — foundational, no spike needed
3. **This PR** (Phase 2 — HID long-press) — *only after spike confirms scenario A or B*
4. Phase 4 — doc 50 Developer ID + notarization (parallel work, recommended in tandem with #3 for GA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
