### PR TITLE
refactor: address full-source review findings (engine hardening + IME polish)

### DIFF
--- a/OngeulApp/Sources/HandleKeyDownRouter.swift
+++ b/OngeulApp/Sources/HandleKeyDownRouter.swift
@@ -45,7 +45,10 @@ func routeKeyDown(
         return .passToSystem
     }
 
-    // Control+[ → Vim ESC 등가
+    // Control+[ → Vim ESC 등가.
+    // KeyEventTap 미설치(접근성 미허용) 시의 폴백 경로 (doc 27 §Phase 2).
+    // 탭 설치 시에는 KeyEventTap.swift의 Control+[ 핸들러가 권위이며, 양 경로가 모두
+    // 발화해도 mode 전환 후 한쪽이 no-op이 되어 실효 실행은 1회다.
     if modifiers.contains(.control)
         && !modifiers.contains(.command)
         && !modifiers.contains(.option)

--- a/OngeulApp/Sources/KeyEventTap.swift
+++ b/OngeulApp/Sources/KeyEventTap.swift
@@ -134,6 +134,10 @@ class KeyEventTap {
                 }
 
                 // === Control+[ → Vim ESC 등가 (이벤트는 소비하지 않고 통과) ===
+                // 이중 경로 주의 (doc 27 §Phase 2): 탭 설치 시 이 경로가 권위이고,
+                // 탭 미설치(접근성 미허용) 시에는 IMK handle() → routeKeyDown의 .escape 분기가 폴백.
+                // 탭 설치 상태에서는 두 경로가 모두 발화하지만, 먼저 실행된 쪽이 flush+영문전환을
+                // 끝내면 나머지는 mode==.english로 인해 no-op이 되므로 실효 실행은 1회다.
                 if type == .keyDown
                     && keyCode == 0x21  // [ key
                     && flags.contains(.maskControl)

--- a/OngeulApp/Sources/OngeulInputController.swift
+++ b/OngeulApp/Sources/OngeulInputController.swift
@@ -464,6 +464,10 @@ class OngeulInputController: IMKInputController {
     private var coordinator: InputStateCoordinator { Self.coordinator }
 
     private var loadedLayoutId: String?
+    /// 로드/파싱에 실패한 레이아웃 id. 키 입력마다 `loadLayoutIfNeeded`가 호출되므로,
+    /// 깨진 레이아웃에 대해 매 키스트로크마다 파일 IO·파싱·에러 로그가 반복되는 것을 막는다.
+    /// 설정에서 다른 레이아웃으로 바꾸면 desiredLayoutId가 달라져 자연히 재시도된다.
+    private var failedLayoutId: String?
     private var toggleDetector = ToggleDetector()
 
     /// 합성 이벤트 마커 (CGEvent userData)
@@ -1259,6 +1263,8 @@ class OngeulInputController: IMKInputController {
     private func loadLayoutIfNeeded() {
         let desiredLayoutId = Self.savedLayoutId
         guard loadedLayoutId != desiredLayoutId else { return }
+        // 이미 실패한 레이아웃이면 키스트로크마다 재시도하지 않는다 (N2).
+        guard failedLayoutId != desiredLayoutId else { return }
 
         let isInitialLoad = (loadedLayoutId == nil)
 
@@ -1275,6 +1281,7 @@ class OngeulInputController: IMKInputController {
 
         guard let url, let json = try? String(contentsOf: url, encoding: .utf8) else {
             os_log("Failed to load layout: %{public}@.json5", log: log, type: .error, desiredLayoutId)
+            failedLayoutId = desiredLayoutId
             return
         }
 
@@ -1284,8 +1291,10 @@ class OngeulInputController: IMKInputController {
                 applyResult(flushResult, to: client)
             }
             loadedLayoutId = desiredLayoutId
+            failedLayoutId = nil
         } catch {
             os_log("Failed to parse layout: %{public}@", log: log, type: .error, String(describing: error))
+            failedLayoutId = desiredLayoutId
         }
     }
 }

--- a/ongeul-automata/src/automata/jamo.rs
+++ b/ongeul-automata/src/automata/jamo.rs
@@ -456,6 +456,11 @@ impl Automata for JamoAutomata {
                     self.buffer.jungseong = Some(prev_v);
                     self.prev_jungseong = None;
                     self.buffer.state = AutomataState::Jungseong;
+                } else {
+                    // 불변식 위반 방어: Jungseong2 진입 시 prev_jungseong은 항상 설정되지만,
+                    // 만약 None이면 정체(stuck) 상태가 되므로 현재 모음을 유지한 채 S2로 강등한다.
+                    crate::warn_unexpected("backspace Jungseong2", "prev_jungseong is None");
+                    self.buffer.state = AutomataState::Jungseong;
                 }
                 AutomataResult::handled(None, self.buffer.to_string())
             }
@@ -476,6 +481,11 @@ impl Automata for JamoAutomata {
                 if let Some(prev_t) = self.prev_jongseong {
                     self.buffer.jongseong = Some(prev_t);
                     self.prev_jongseong = None;
+                    self.buffer.state = AutomataState::Jongseong;
+                } else {
+                    // 불변식 위반 방어: prev_jongseong이 None이면 정체 상태가 되므로
+                    // 현재(겹)종성을 유지한 채 S4로 강등한다 (다음 backspace에서 종성 전체 제거).
+                    crate::warn_unexpected("backspace Jongseong2", "prev_jongseong is None");
                     self.buffer.state = AutomataState::Jongseong;
                 }
                 AutomataResult::handled(None, self.buffer.to_string())

--- a/ongeul-automata/src/automata/jaso.rs
+++ b/ongeul-automata/src/automata/jaso.rs
@@ -269,6 +269,10 @@ impl Automata for JasoAutomata {
                     self.buffer.jongseong = Some(prev_t);
                     self.prev_jongseong = None;
                     self.buffer.state = AutomataState::Jongseong;
+                } else {
+                    // 불변식 위반 방어: prev_jongseong이 None이면 정체 상태가 되므로 S4로 강등.
+                    crate::warn_unexpected("backspace Jongseong2 (jaso)", "prev_jongseong is None");
+                    self.buffer.state = AutomataState::Jongseong;
                 }
                 AutomataResult::handled(None, self.buffer.to_string())
             }
@@ -290,6 +294,10 @@ impl Automata for JasoAutomata {
                 if let Some(prev_v) = self.prev_jungseong {
                     self.buffer.jungseong = Some(prev_v);
                     self.prev_jungseong = None;
+                    self.buffer.state = AutomataState::Jungseong;
+                } else {
+                    // 불변식 위반 방어: prev_jungseong이 None이면 정체 상태가 되므로 S2로 강등.
+                    crate::warn_unexpected("backspace Jungseong2 (jaso)", "prev_jungseong is None");
                     self.buffer.state = AutomataState::Jungseong;
                 }
                 AutomataResult::handled(None, self.buffer.to_string())

--- a/ongeul-automata/src/lib.rs
+++ b/ongeul-automata/src/lib.rs
@@ -5,6 +5,7 @@ pub mod unicode;
 
 use std::sync::{Mutex, MutexGuard};
 
+use automata::AutomataResult;
 use engine::EngineState;
 
 uniffi::setup_scaffolding!();
@@ -24,6 +25,16 @@ pub struct ProcessResult {
     pub composing: Option<String>,
     /// 키가 처리되었는지 (false면 시스템에 위임)
     pub handled: bool,
+}
+
+impl From<AutomataResult> for ProcessResult {
+    fn from(r: AutomataResult) -> Self {
+        ProcessResult {
+            committed: r.committed,
+            composing: r.composing,
+            handled: r.handled,
+        }
+    }
 }
 
 /// 엔진 에러 (UniFFI → Swift 전달용)
@@ -102,10 +113,20 @@ impl HangulEngine {
     }
 
     /// 입력 모드를 설정한다.
+    ///
+    /// # 호출 계약 (중요)
+    /// 한글 → 영문 전환 시 조합 중이던 글자를 내부적으로 flush하지만 그 **확정 텍스트(committed)는
+    /// 폐기**한다. 따라서 조합 중인 텍스트가 있을 수 있는 상태에서 모드를 바꿀 때는 **반드시
+    /// 호출자가 먼저 [`flush`](Self::flush)(또는 결과를 반환하는 [`toggle_mode`](Self::toggle_mode))를
+    /// 호출해 committed를 client에 적용**해야 한다. 그렇지 않으면 확정 텍스트가 소리 없이 사라진다.
+    ///
+    /// 내부 flush는 "호출자가 flush를 누락했더라도 다음 한글 입력에 잔여 조합이 되살아나지 않도록"
+    /// 하는 방어적 폐기일 뿐, 데이터 전달 경로가 아니다. 현재 Swift `InputStateCoordinator`의
+    /// 모든 한→영 경로는 이 계약을 지켜 set_mode 이전에 flush 결과를 적용한다.
     pub fn set_mode(&self, mode: InputMode) {
         let mut state = self.lock_state();
         if state.mode == engine::InputMode::Korean && mode == InputMode::English {
-            // 한→영 전환 시 현재 조합 확정
+            // 한→영 전환 시 잔여 조합을 폐기한다 (committed는 호출자가 별도 flush로 이미 적용했어야 함 — 위 계약 참조).
             let _ = state.flush();
         }
         state.mode = mode.into();
@@ -123,11 +144,7 @@ impl HangulEngine {
         if state.mode == engine::InputMode::Korean {
             let result = state.flush();
             state.mode = engine::InputMode::English;
-            ProcessResult {
-                committed: result.committed,
-                composing: result.composing,
-                handled: true,
-            }
+            result.into()
         } else {
             state.mode = engine::InputMode::Korean;
             ProcessResult {
@@ -141,34 +158,19 @@ impl HangulEngine {
     /// 키 레이블을 처리한다. (예: "q", "Q", "k")
     pub fn process_key(&self, key: String) -> ProcessResult {
         let mut state = self.lock_state();
-        let result = state.process_key(&key);
-        ProcessResult {
-            committed: result.committed,
-            composing: result.composing,
-            handled: result.handled,
-        }
+        state.process_key(&key).into()
     }
 
     /// 백스페이스 처리 (오토마타 한 단계 되돌림)
     pub fn backspace(&self) -> ProcessResult {
         let mut state = self.lock_state();
-        let result = state.backspace();
-        ProcessResult {
-            committed: result.committed,
-            composing: result.composing,
-            handled: result.handled,
-        }
+        state.backspace().into()
     }
 
     /// 현재 조합을 확정한다.
     pub fn flush(&self) -> ProcessResult {
         let mut state = self.lock_state();
-        let result = state.flush();
-        ProcessResult {
-            committed: result.committed,
-            composing: result.composing,
-            handled: result.handled,
-        }
+        state.flush().into()
     }
 
     /// 현재 조합을 폐기한다.

--- a/ongeul-automata/src/unicode.rs
+++ b/ongeul-automata/src/unicode.rs
@@ -61,12 +61,6 @@ pub fn decompose_syllable(ch: char) -> Option<(u32, u32, u32)> {
     Some((l, v, t))
 }
 
-/// 초성/중성/종성 인덱스로 음절 문자열을 만든다.
-/// 종성이 None이면 종성 없는 음절.
-pub fn compose_syllable_char(l: u32, v: u32, t: Option<u32>) -> Option<char> {
-    compose_syllable(l, v, t.unwrap_or(0))
-}
-
 // ── 호환 자모 ↔ 위치 자모 변환 ──
 
 /// 호환 자모 자음 → 초성 인덱스 (L index)


### PR DESCRIPTION
전체 소스 리뷰에서 도출한 개선 사항을 적용합니다. 동작 변경이 없는 견고성·정리 위주이며, 엔진 테스트 150개 통과·clippy 클린입니다.

## Rust 엔진 (`refactor(automata)`)
- **`set_mode` 호출 계약 문서화** — 한→영 전환 시 조합 중 `committed`가 내부적으로 폐기되므로, 호출자가 먼저 `flush`(또는 `toggle_mode`)로 확정 텍스트를 적용해야 함을 doc-comment로 명시. 현재 모든 호출 경로는 이 계약을 지키지만, 미래의 무성(silent) 데이터 손실을 차단.
- **백스페이스 정체(stuck) 상태 방어** — `Jungseong2`/`Jongseong2`에서 `prev_*`가 `None`인 불변식 위반 시 동일 상태로 정체되던 것을, 한 단계 아래 상태로 안전 강등(jamo + jaso).
- **`From<AutomataResult> for ProcessResult` 도입** — `toggle_mode`/`process_key`/`backspace`/`flush` 4곳의 수기 필드 복사 제거.
- **죽은 코드 제거** — `compose_syllable_char`(= `compose_syllable` 중복, 미사용) 삭제.

> 참고: 테스트 전용 public 함수들의 `pub(crate)` 강등은 일반 라이브러리 빌드에서 `dead_code` 경고를 유발해 역효과임을 실측 확인, 보류함.

## Swift IME (`refactor(ime)`)
- **레이아웃 로드 실패 메모이제이션** — 깨진 레이아웃에 대해 키스트로크마다 반복되던 파일 IO·파싱·에러 로그를 1회로 차단(`failedLayoutId`). 설정 변경 시 자연히 재시도.
- **Control+\[ 이중 경로 의도 명시** — `KeyEventTap`(탭 설치 시 권위) ↔ `routeKeyDown`(접근성 미허용 폴백) 설계를 양쪽에 주석화(doc 27 §Phase 2). 실효 실행은 항상 1회(먼저 실행된 쪽이 영문 전환 후 나머지는 no-op)이므로 구조 변경 없이 의도만 문서화.

## 검증
- `cargo test -p ongeul-automata` — 150 passed
- `cargo clippy --all-targets` — 0 warnings
- Swift 변경은 자명하나(인스턴스 변수 1·guard 2·할당 2·주석), 컴파일 검증은 전체 앱 빌드(`scripts/build.sh`)가 필요 — 미수행.

🤖 Generated with [Claude Code](https://claude.com/claude-code)