### PR TITLE
fix(ime): keystroke-buffer privacy, composing preservation, and source-review hardening

### DIFF
--- a/OngeulApp/Sources/InputStateCoordinator.swift
+++ b/OngeulApp/Sources/InputStateCoordinator.swift
@@ -114,6 +114,12 @@ final class InputStateCoordinator: FocusStealModeController {
         } else {
             mode = .english
         }
+        // 같은 앱 재활성화(!isAppSwitch)에서 한→영 전환 시 조합 중 텍스트를 보존한다.
+        // set_mode는 한→영 시 조합을 폐기하므로(lib.rs 계약), 호출 전에 flush해 그
+        // committed를 StateEffect로 전달 → applyEffect가 현재(같은) client에 삽입한다.
+        // 앱 전환 시엔 위 reset()이 이미 버퍼를 비웠고 다른 client이므로 보존하지 않는다.
+        let flushResult = (!isAppSwitch && engine.getMode() == .korean && mode == .english)
+            ? engine.flush() : nil
         setMode(mode)
         perAppStore.saveMode(mode, for: bundleId)
 
@@ -124,6 +130,7 @@ final class InputStateCoordinator: FocusStealModeController {
         let modeChanged = prevMode != nil && prevMode != mode
 
         return StateEffect(
+            processResult: flushResult,
             modeChanged: modeChanged,
             lockOverlay: isAppSwitch ? .hide : nil
         )

--- a/OngeulApp/Sources/KeyEventTap.swift
+++ b/OngeulApp/Sources/KeyEventTap.swift
@@ -18,6 +18,27 @@ class KeyEventTap {
     static var keyBuffer: [RecordedKey] = []
     static var keyBufferWasKoreanMode = false
 
+    // keyBuffer 강제 만료: 입력이 멈춘 뒤 복호화된 (민감할 수 있는) 문자가 메모리에
+    // 무기한 남지 않도록 한다. activateServer/modifier 외에는 다음 keyDown 시에만
+    // lazy prune 되므로, 키 입력이 끊기면 잔존했다. 만료 시각을 focus-steal 의 포기
+    // 임계값(첫 키 0.5s 경과 시 보정 포기 — FocusStealCorrector)과 정렬해, 마지막
+    // 입력 +0.5s 후 비워도 보정에 실제로 쓰일 키는 제거하지 않는다.
+    private static let keyBufferMaxLifetime: TimeInterval = 0.5
+    private static var keyBufferExpiryTask: DispatchWorkItem?
+
+    /// keyBuffer 강제 만료 타이머를 (재)예약한다. 키 append 시마다 호출.
+    /// 모두 메인 런루프에서 실행되므로 별도 동기화 불필요.
+    static func scheduleKeyBufferExpiry() {
+        keyBufferExpiryTask?.cancel()
+        let task = DispatchWorkItem {
+            KeyEventTap.keyBuffer.removeAll()
+            KeyEventTap.keyBufferExpiryTask = nil
+        }
+        keyBufferExpiryTask = task
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + keyBufferMaxLifetime, execute: task)
+    }
+
     // 현재 입력 모드 (모드 변경 시 OngeulInputController에서 갱신)
     static var currentInputMode: InputMode = .english
 
@@ -125,7 +146,10 @@ class KeyEventTap {
                                 character: label,
                                 timestamp: now
                             ))
-                            os_log("focusSteal: recorded key='%{public}@' koreanMode=%d bufSize=%d",
+                            KeyEventTap.scheduleKeyBufferExpiry()
+                            // 복호화된 타이핑 문자는 민감할 수 있으므로 private 으로 로깅
+                            // (통합 로그에 평문 키가 남지 않도록). bufSize/koreanMode 만 public.
+                            os_log("focusSteal: recorded key='%{private}@' koreanMode=%d bufSize=%d",
                                    log: log, type: .debug, label,
                                    KeyEventTap.keyBufferWasKoreanMode,
                                    KeyEventTap.keyBuffer.count)


### PR DESCRIPTION
## Summary

Three new fixes from a multi-perspective source review (Rust correctness · Swift concurrency/lifecycle · FFI boundary · security · architecture), **plus** two earlier source-review commits.

> ⚠️ **Branch note:** PR #17 is marked *merged*, but its two commits (`ed6fdf5`, `3cda49a`) are not actually in `origin/main` (`git cherry origin/main HEAD` reports both as `+`). This PR re-includes them so the source-review work lands in `main`.

## New in this PR (`3ef0b34`)

- **Privacy — keystroke logging** ([KeyEventTap.swift](OngeulApp/Sources/KeyEventTap.swift)): log recorded focus-steal characters at `%{private}` instead of `%{public}`, so plaintext keystrokes don't surface in the unified log.
- **Memory hygiene — keyBuffer expiry** ([KeyEventTap.swift](OngeulApp/Sources/KeyEventTap.swift)): add a hard 0.5s expiry timer for `keyBuffer` so decoded characters don't linger in memory after typing stops. The timeout is aligned with focus-steal's own give-up threshold (first key > 0.5s old), so keys it would actually replay are provably never removed — the feature is preserved.
- **Correctness — `activateApp` flush contract** ([InputStateCoordinator.swift](OngeulApp/Sources/InputStateCoordinator.swift)): on same-app re-activation (no intervening `deactivateServer`), honor `set_mode`'s flush contract — capture the flush result on Korean→English and surface it via `StateEffect`, so an in-progress composing syllable isn't silently dropped. The app-switch path is unchanged (`reset()` already clears the buffer there).

## Also lands (from PR #17, not yet in `main`)

- `3cda49a` — refactor(automata): harden engine per source review (jamo/jaso/lib/unicode)
- `ed6fdf5` — refactor(ime): stop per-keystroke layout retry; document Control+[ dual-path

## Review notes

- Other findings from the review were verified and **dropped** as overstated or refuted (e.g. a claimed 세벌식 ssang-consonant backspace "bug" turned out to be intended, consistent keystroke-reversal; distributed-notification threading and HID `stop()` ordering were refuted as main-run-loop-serialized).
- The `keyBuffer` expiry was originally proposed as "clear on `deactivateServer`," but that would break focus-steal (which relies on the buffer surviving deactivate→activate). The hard-timer approach was chosen specifically to avoid that regression — worth a manual check of focus-steal (Korean replay during app focus changes).

## Verification

- `./scripts/build.sh` — Swift compile + bundle + sign OK
- `cargo test -p ongeul-automata` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)