### PR TITLE
perf(ime): gate focus-steal key buffer on Korean mode; trim event-tap hot path

### DIFF
--- a/OngeulApp/Sources/HandleKeyDownRouter.swift
+++ b/OngeulApp/Sources/HandleKeyDownRouter.swift
@@ -81,12 +81,8 @@ func routeKeyDown(
         return .escape
     }
 
-    // 방향키 → flush 후 통과
-    let arrowKeys: Set<UInt16> = [
-        KeyCode.arrowLeft, KeyCode.arrowRight,
-        KeyCode.arrowDown, KeyCode.arrowUp,
-    ]
-    if arrowKeys.contains(keyCode) {
+    // 방향키 → flush 후 통과 (KeyCode.arrowKeys는 static — 매 키 할당 회피)
+    if KeyCode.arrowKeys.contains(keyCode) {
         return .flushAndPassToSystem
     }
 

--- a/OngeulApp/Sources/KeyCodes.swift
+++ b/OngeulApp/Sources/KeyCodes.swift
@@ -17,6 +17,10 @@ enum KeyCode {
     static let arrowDown: UInt16  = 125
     static let arrowUp: UInt16    = 126
 
+    /// 방향키 키코드 집합. routeKeyDown 핫패스에서 매 키마다 Set 리터럴을
+    /// 새로 할당하지 않도록 static으로 한 번만 생성한다.
+    static let arrowKeys: Set<UInt16> = [arrowLeft, arrowRight, arrowDown, arrowUp]
+
     /// 키패드(텐키) 키코드 집합. Enter(0x4C)는 제외 — 일반 Enter와 통합 처리.
     /// kVK_ANSI_Keypad* (Decimal, Multiply, Plus, Clear, Divide, Minus, Equals, 0-9)
     static let numpadKeys: Set<UInt16> = [

--- a/OngeulApp/Sources/KeyEventTap.swift
+++ b/OngeulApp/Sources/KeyEventTap.swift
@@ -116,43 +116,56 @@ class KeyEventTap {
 
                     KeyEventTap.toggleDetector.cancelOnKeyDown()
 
-                    // Modifier 단축키(cmd, ctrl, option)는 텍스트 입력이 아니므로
-                    // focus-steal 버퍼에 기록하지 않는다.
-                    let hasModifier = flags.contains(.maskCommand)
-                        || flags.contains(.maskControl)
-                        || flags.contains(.maskAlternate)
+                    // focus-steal 키 버퍼 기록은 한글 모드에서만 의미가 있다.
+                    // 소비처(activateServer)가 keyBufferWasKoreanMode로 게이트하므로 영문 모드
+                    // 기록은 시스템 전역 키마다 헛도는 할당·GCD 타이머(scheduleKeyBufferExpiry)
+                    // churn일 뿐이고, 복호화된 영문 키가 메모리에 남아 프라이버시에도 불리하다.
+                    // 버퍼링 윈도우 중 후발 키는 forceKoreanForReplay가 이미 currentInputMode를
+                    // .korean으로 동기 설정한 뒤이므로 이 게이트를 통과해 정상 캡처된다.
+                    if KeyEventTap.currentInputMode == .korean {
+                        // Modifier 단축키(cmd, ctrl, option)는 텍스트 입력이 아니므로
+                        // focus-steal 버퍼에 기록하지 않는다.
+                        let hasModifier = flags.contains(.maskCommand)
+                            || flags.contains(.maskControl)
+                            || flags.contains(.maskAlternate)
 
-                    var length = 0
-                    var chars = [UniChar](repeating: 0, count: 4)
-                    event.keyboardGetUnicodeString(
-                        maxStringLength: 4, actualStringLength: &length, unicodeString: &chars)
-                    if hasModifier {
-                        KeyEventTap.keyBuffer.removeAll()
-                    } else if length > 0 {
-                        let str = String(utf16CodeUnits: chars, count: length)
-                        let capsLock = flags.contains(.maskAlphaShift)
-                        let shift = flags.contains(.maskShift)
-                        if let label = keyLabel(characters: str, capsLock: capsLock, shift: shift) {
-                            let now = CFAbsoluteTimeGetCurrent()
-                            // 첫 키가 200ms보다 오래되면 버퍼 리셋 (메모리 증가 방지)
-                            if let first = KeyEventTap.keyBuffer.first,
-                               now - first.timestamp > 0.2 {
-                                KeyEventTap.keyBuffer.removeAll()
+                        if hasModifier {
+                            KeyEventTap.keyBuffer.removeAll()
+                        } else {
+                            // 비modifier 키일 때만 유니코드 문자열을 추출한다 — modifier
+                            // 단축키에서 호출 후 폐기하던 keyboardGetUnicodeString 비용 제거.
+                            var length = 0
+                            var chars = [UniChar](repeating: 0, count: 4)
+                            event.keyboardGetUnicodeString(
+                                maxStringLength: 4, actualStringLength: &length, unicodeString: &chars)
+                            if length > 0 {
+                                let str = String(utf16CodeUnits: chars, count: length)
+                                let capsLock = flags.contains(.maskAlphaShift)
+                                let shift = flags.contains(.maskShift)
+                                if let label = keyLabel(characters: str, capsLock: capsLock, shift: shift) {
+                                    let now = CFAbsoluteTimeGetCurrent()
+                                    // 첫 키가 200ms보다 오래되면 버퍼 리셋 (메모리 증가 방지)
+                                    if let first = KeyEventTap.keyBuffer.first,
+                                       now - first.timestamp > 0.2 {
+                                        KeyEventTap.keyBuffer.removeAll()
+                                    }
+                                    if KeyEventTap.keyBuffer.isEmpty {
+                                        // 이 블록은 한글 모드 게이트 내부이므로 항상 true.
+                                        KeyEventTap.keyBufferWasKoreanMode = true
+                                    }
+                                    KeyEventTap.keyBuffer.append(RecordedKey(
+                                        character: label,
+                                        timestamp: now
+                                    ))
+                                    KeyEventTap.scheduleKeyBufferExpiry()
+                                    // 복호화된 타이핑 문자는 민감할 수 있으므로 private 으로 로깅
+                                    // (통합 로그에 평문 키가 남지 않도록). bufSize/koreanMode 만 public.
+                                    os_log("focusSteal: recorded key='%{private}@' koreanMode=%d bufSize=%d",
+                                           log: log, type: .debug, label,
+                                           KeyEventTap.keyBufferWasKoreanMode,
+                                           KeyEventTap.keyBuffer.count)
+                                }
                             }
-                            if KeyEventTap.keyBuffer.isEmpty {
-                                KeyEventTap.keyBufferWasKoreanMode = (KeyEventTap.currentInputMode == .korean)
-                            }
-                            KeyEventTap.keyBuffer.append(RecordedKey(
-                                character: label,
-                                timestamp: now
-                            ))
-                            KeyEventTap.scheduleKeyBufferExpiry()
-                            // 복호화된 타이핑 문자는 민감할 수 있으므로 private 으로 로깅
-                            // (통합 로그에 평문 키가 남지 않도록). bufSize/koreanMode 만 public.
-                            os_log("focusSteal: recorded key='%{private}@' koreanMode=%d bufSize=%d",
-                                   log: log, type: .debug, label,
-                                   KeyEventTap.keyBufferWasKoreanMode,
-                                   KeyEventTap.keyBuffer.count)
                         }
                     }
                 }


### PR DESCRIPTION
## 배경

세션 전역 `CGEventTap` 콜백은 **Ongeul 프로세스가 살아있는 동안 시스템 전체의 모든 키 이벤트**에 대해 메인 스레드에서 실행됩니다. 여기서 focus-steal `keyBuffer` 기록이 **입력 모드와 무관하게 매 키마다** 돌고 있었는데, replay는 직전 타이핑이 한글 모드였을 때만 의미가 있습니다(`activateServer`가 `keyBufferWasKoreanMode`로 게이트). 즉 영문 모드 기록은 전역 키마다 헛도는 비용일 뿐이고, 복호화된 영문 키가 메모리에 남아 프라이버시에도 불리했습니다.

체감 지연(latency) 문제가 아니라 **불필요한 전역 per-keystroke 작업·GCD 타이머 churn 제거 + 프라이버시 개선**이 목적입니다.

## 변경 사항

- **#1 — 한글 모드 게이트** (`KeyEventTap.swift`): focus-steal 기록 블록을 `currentInputMode == .korean`으로 게이트. 버퍼링 윈도우 중 후발 키는 `forceKoreanForReplay`가 `.korean`을 동기 설정한 뒤이므로 그대로 캡처됩니다.
- **#2 — `keyboardGetUnicodeString` 조건부 호출** (`KeyEventTap.swift`): cmd/ctrl/opt 단축키에서 호출 후 폐기하던 것을 비-modifier 키일 때만 호출하도록 이동.
- **#3 — `arrowKeys` static화** (`KeyCodes.swift` / `HandleKeyDownRouter.swift`): `routeKeyDown` 핫패스에서 매 키마다 새로 할당되던 `Set<UInt16>` 리터럴을 `KeyCode.arrowKeys` static으로 (`KeyCode.numpadKeys`와 동일 패턴).

## 안전성

- 소비처(`activateServer`)의 `keyBufferWasKoreanMode && !buffer.isEmpty` 게이트와 동치 — 한글일 때만 버퍼가 차므로 동작 동등.
- 토글 직후 잔존 한글 키는 expiry 타이머(0.5s) + `activateServer`의 0.2s prune으로 자가 소멸.
- `#3`은 `KeyCode.arrowKeys = {123,124,125,126}`로 기존 지역 Set과 내용·`.contains` 의미 완전 동일 → arrow 라우팅 동작 불변.

## 검증

- `swiftc -typecheck` (build.sh와 동일한 전체 소스 경로): **0 errors**
- Rust 엔진 테스트: 그대로 green (Swift만 변경)

> 참고: `Ongeul.xcodeproj`에 `CapsLockHIDMonitor.swift`가 누락되어 `xcodebuild test`가 사전부터 컴파일 불가 상태입니다(이 PR과 무관한 별개 이슈). 실제 앱 빌드(`build.sh`)는 전체 소스를 컴파일하므로 정상입니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)