### PR TITLE
feat(ime): add Han/Yeong key toggle option for external keyboards

### DIFF
--- a/OngeulApp/Resources/en.lproj/Localizable.strings
+++ b/OngeulApp/Resources/en.lproj/Localizable.strings
@@ -16,6 +16,7 @@
 "prefs.toggleKey.label" = "Toggle Key:";
 "prefs.toggleKey.rightCommand" = "Right Command";
 "prefs.toggleKey.rightOption" = "Right Option";
+"prefs.toggleKey.hangulKey" = "Han/Yeong key (external keyboard)";
 "prefs.toggleKey.leftShift" = "Left Shift (tap)";
 "prefs.toggleKey.rightShift" = "Right Shift (tap)";
 "prefs.toggleKey.shiftSpace" = "Shift + Space";

--- a/OngeulApp/Resources/ko.lproj/Localizable.strings
+++ b/OngeulApp/Resources/ko.lproj/Localizable.strings
@@ -16,6 +16,7 @@
 "prefs.toggleKey.label" = "한/영 전환 키:";
 "prefs.toggleKey.rightCommand" = "오른쪽 Command";
 "prefs.toggleKey.rightOption" = "오른쪽 Option";
+"prefs.toggleKey.hangulKey" = "한/영 키 (외장 키보드)";
 "prefs.toggleKey.leftShift" = "왼쪽 Shift (단독)";
 "prefs.toggleKey.rightShift" = "오른쪽 Shift (단독)";
 "prefs.toggleKey.shiftSpace" = "Shift + Space";

--- a/OngeulApp/Sources/HandleKeyDownRouter.swift
+++ b/OngeulApp/Sources/HandleKeyDownRouter.swift
@@ -4,6 +4,8 @@ import AppKit
 enum KeyDownAction: Equatable {
     /// Shift+Space 한/영 전환 (shiftSpace 모드)
     case shiftSpaceToggle
+    /// 한/영 키(외장 한국어 키보드, keycode 104) 한/영 전환 (hangulKey 모드)
+    case hangulKeyToggle
     /// 영문 모드: 시스템에 위임
     case passToSystem
     /// Cmd/Ctrl 단축키 또는 방향키: flush 후 시스템에 위임
@@ -38,6 +40,14 @@ func routeKeyDown(
         && !modifiers.contains(.command)
         && !modifiers.contains(.control) {
         return .shiftSpaceToggle
+    }
+
+    // 한/영 전용 키 (hangulKey 모드) → 한/영 전환.
+    // CGEventTap 미설치(접근성 미허용) 시의 폴백 경로. 탭 설치 시에는 KeyEventTap이
+    // keycode 104를 소비하므로 IMK까지 도달하지 않는다(shiftSpace와 동일 이중 경로).
+    // 영문 모드 early-return 앞에 위치해야 영문→한글 전환이 가능하다.
+    if toggleKey == .hangulKey && keyCode == KeyCode.hangul {
+        return .hangulKeyToggle
     }
 
     // 영문 모드: 전환 키 외 모든 키를 시스템에 위임

--- a/OngeulApp/Sources/InputStateCoordinator.swift
+++ b/OngeulApp/Sources/InputStateCoordinator.swift
@@ -10,6 +10,13 @@ final class InputStateCoordinator: FocusStealModeController {
     private let lockStore = EnglishLockStore()
     private(set) var activeAppBundleId: String?
 
+    /// TIS dirty 플래그 (doc 34): 엔진 모드가 바뀌었지만 TIS(selectMode)에 아직 반영되지
+    /// 않았을 수 있는 상태. dirty 동안 activateApp의 "TIS 우선" 규칙을 스킵해, clientless
+    /// flip(또는 selectMode 디바운스 창)에서 TIS가 구 모드로 남아 있어도 방금 한 전환이
+    /// 롤백·per-app 영구 덮어쓰기되지 않도록 한다. activateApp에서 systemMode == 엔진 모드가
+    /// 관측되면 청산된 것으로 보고 내린다.
+    private(set) var tisDirty = false
+
     // MARK: - Read-only
 
     var mode: InputMode { engine.getMode() }
@@ -43,6 +50,9 @@ final class InputStateCoordinator: FocusStealModeController {
     /// - `syncCapsLock: false`는 CapsLock 누름 자체가 모드 변경을 일으킨 경로에서 사용:
     ///   하드웨어가 이미 LED를 변경했으므로 재설정은 echo만 만듦 (shouldHandle이 걸러내긴 하지만 불필요).
     private func setMode(_ mode: InputMode, syncCapsLock: Bool = true) {
+        // 실제 모드가 바뀔 때만 TIS dirty — no-op set(같은 모드 재설정)에 dirty를 세우면
+        // 정상 상태에서 "메뉴바 직접 전환" 감지(activateApp 우선순위 1)가 영구 무력화된다.
+        if engine.getMode() != mode { tisDirty = true }
         engine.setMode(mode: mode)
         KeyEventTap.currentInputMode = mode
         if syncCapsLock
@@ -58,6 +68,7 @@ final class InputStateCoordinator: FocusStealModeController {
     private func toggleEngineMode() -> ProcessResult {
         let result = engine.toggleMode()
         let mode = engine.getMode()
+        tisDirty = true  // toggle은 항상 모드 변경
         KeyEventTap.currentInputMode = mode
         if KeyEventTap.toggleKey == .capsLock
             && CapsLockHIDMonitor.shared.mode == .cgEventTapAuthority {
@@ -94,6 +105,7 @@ final class InputStateCoordinator: FocusStealModeController {
         // English Lock 우선
         if lockStore.isLocked(bundleId) {
             setMode(.english)
+            if systemMode == .english { tisDirty = false }  // TIS 동기 관측 (doc 34)
             return StateEffect(
                 lockOverlay: isAppSwitch ? .show(locked: true) : nil
             )
@@ -101,11 +113,14 @@ final class InputStateCoordinator: FocusStealModeController {
 
         // 모드 결정 우선순위:
         // 1. systemMode가 현재 엔진 모드와 다르면 → 사용자가 메뉴바에서 직접 전환. TIS 우선.
+        //    단 tisDirty 동안은 스킵 (doc 34): 엔진이 flip됐지만 selectMode가 아직 TIS에
+        //    반영되지 않은 상태라, 이 mismatch는 사용자 행위가 아니다. 스킵하지 않으면
+        //    방금 한 전환이 구 모드로 롤백되고 아래 saveMode가 per-app에 영구 기록한다.
         // 2. per-app 저장 모드 → 앱별 기억 복원.
         // 3. systemMode (fallback) → 최초 활성화 시 TIS 따름.
         // 4. .english (최종 기본값).
         let mode: InputMode
-        if let systemMode, systemMode != engine.getMode() {
+        if !tisDirty, let systemMode, systemMode != engine.getMode() {
             mode = systemMode
         } else if let stored = perAppStore.savedMode(for: bundleId) {
             mode = stored
@@ -121,6 +136,9 @@ final class InputStateCoordinator: FocusStealModeController {
         let flushResult = (!isAppSwitch && engine.getMode() == .korean && mode == .english)
             ? engine.flush() : nil
         setMode(mode)
+        // TIS가 최종 결정 모드와 일치하면 동기화 관측 → dirty 청산 (doc 34).
+        // rule 1로 TIS를 채택한 경우도 여기서 자연히 청산된다.
+        if systemMode == mode { tisDirty = false }
         perAppStore.saveMode(mode, for: bundleId)
 
         // 앱 전환 시 이전 앱과 모드가 다르면 아이콘 동기화
@@ -200,6 +218,7 @@ final class InputStateCoordinator: FocusStealModeController {
     func setModeFromExternal(_ mode: InputMode, for bundleId: String?) -> ProcessResult? {
         let flushResult = (self.mode == .korean) ? engine.flush() : nil
         setMode(mode)
+        tisDirty = false  // 시스템(TIS) 발 변경 → 엔진이 방금 TIS에 맞춰졌으므로 동기 상태 (doc 34)
         if let bundleId { perAppStore.saveMode(mode, for: bundleId) }
         return flushResult
     }

--- a/OngeulApp/Sources/KeyCodes.swift
+++ b/OngeulApp/Sources/KeyCodes.swift
@@ -11,6 +11,9 @@ enum KeyCode {
     static let leftOption: UInt16 = 58
     static let rightShift: UInt16 = 60
     static let rightOption: UInt16 = 61
+    /// 한/영 키 (kVK_JIS_Kana 위치, 0x68). 한국어 전용 외장 키보드의 한영 전환 키가
+    /// 이 키코드를 보낸다. 한자 키는 kVK_JIS_Eisu(0x66=102) — 현재 미사용.
+    static let hangul: UInt16     = 0x68  // 104
     static let leftBracket: UInt16 = 0x21  // [ key
     static let arrowLeft: UInt16  = 123
     static let arrowRight: UInt16 = 124

--- a/OngeulApp/Sources/KeyEventTap.swift
+++ b/OngeulApp/Sources/KeyEventTap.swift
@@ -284,11 +284,20 @@ class KeyEventTap {
                     if CapsLockSync.shouldHandle(capsLockOn: capsLockOn) {
                         os_log("capsLock flagsChanged: capsLockOn=%{public}d (user)",
                                log: log, type: .debug, capsLockOn)
-                        if let controller = KeyEventTap.resolvedController,
-                           !controller.isCurrentAppLocked() {
-                            // 동기 호출: CapsLock은 key press 시점에 발생하므로
-                            // async를 사용하면 다음 keyDown이 모드 전환 전에 도착할 수 있다.
-                            controller.performCapsLockModeSet(korean: capsLockOn)
+                        if let controller = KeyEventTap.resolvedController {
+                            if !controller.isCurrentAppLocked() {
+                                // 동기 호출: CapsLock은 key press 시점에 발생하므로
+                                // async를 사용하면 다음 keyDown이 모드 전환 전에 도착할 수 있다.
+                                controller.performCapsLockModeSet(korean: capsLockOn)
+                            }
+                        } else if OngeulInputController.isOngeulActiveInputSource() {
+                            // 컨트롤러 부재(IMK 세션 공백)에도 SET은 수행 (doc 34).
+                            // 이 flagsChanged 경로는 IMK 폴백이 없어(handleFlagsChanged가
+                            // 탭 설치 시 스킵) 여기서 놓치면 블랙홀이다.
+                            os_log("capsLock: no controller → static SET",
+                                   log: log, type: .error)
+                            OngeulInputController.performStaticCapsLockModeSet(
+                                korean: capsLockOn)
                         }
                     } else {
                         os_log("capsLock flagsChanged: capsLockOn=%{public}d (echo, filtered)",
@@ -309,11 +318,24 @@ class KeyEventTap {
                     )
                     switch action {
                     case .toggle:
-                        if let controller = KeyEventTap.resolvedController,
-                           !controller.isCurrentAppLocked() {
-                            os_log("modifier tap intercepted, toggling", log: log, type: .debug)
+                        if let controller = KeyEventTap.resolvedController {
+                            if !controller.isCurrentAppLocked() {
+                                os_log("modifier tap intercepted, toggling%{public}@",
+                                       log: log, type: .default,
+                                       KeyEventTap.activeController == nil
+                                           ? " [lastController fallback]" : "")
+                                DispatchQueue.main.async {
+                                    controller.performToggleFromTap()
+                                }
+                            }
+                        } else if OngeulInputController.isOngeulActiveInputSource() {
+                            // 컨트롤러 부재(앱 자가업데이트 후 IMK 세션 공백 등)에도 flip은
+                            // 수행 (doc 34). modifier 경로는 이벤트를 소비하지 않지만 IMK
+                            // 폴백이 탭 설치 시 차단되므로, 여기서 놓치면 토글이 조용히 죽는다.
+                            os_log("modifier tap: no controller → static flip",
+                                   log: log, type: .error)
                             DispatchQueue.main.async {
-                                controller.performToggleFromTap()
+                                OngeulInputController.performStaticToggleFromTap()
                             }
                         }
                     case .englishLockToggle:
@@ -322,6 +344,11 @@ class KeyEventTap {
                             DispatchQueue.main.async {
                                 controller.performEnglishLockToggleFromTap()
                             }
+                        } else {
+                            // Lock 토글은 컨트롤러(bundleId·lock 캐시 갱신)가 필요해 정적
+                            // 경로를 두지 않는다 — 무시하되 진단 가능하게 로그만 남긴다 (doc 34).
+                            os_log("4-key English Lock: no controller, ignored",
+                                   log: log, type: .error)
                         }
                     case .none:
                         break

--- a/OngeulApp/Sources/KeyEventTap.swift
+++ b/OngeulApp/Sources/KeyEventTap.swift
@@ -239,6 +239,34 @@ class KeyEventTap {
                     return nil
                 }
 
+                // === 한/영 전용 키 처리 (hangulKey 모드) ===
+                // 한국어 전용 외장 키보드의 한/영 키(kVK_JIS_Kana, keycode 104)를 한영 토글로 사용.
+                // shiftSpace와 동일 구조: keyDown에서 토글하고, keyDown/keyUp을 모두 소비해
+                // keycode 104가 앱이나 시스템 입력 소스 전환으로 누출되지 않게 한다.
+                // 살아있는 client가 없으면 통과 → IMK handle() → routeKeyDown(.hangulKeyToggle)
+                // 폴백이 진짜 포커스된 세션에서 처리한다 (doc 33).
+                if KeyEventTap.toggleKey == .hangulKey
+                    && keyCode == Int64(KeyCode.hangul) {
+                    let controller = KeyEventTap.resolvedController
+                    guard let controller, controller.hasLiveClient else {
+                        if type == .keyDown {
+                            os_log("Hangul key: no live controller → IMK fallback",
+                                   log: log, type: .error)
+                        }
+                        return Unmanaged.passUnretained(event)
+                    }
+                    // English Lock 중에는 토글하지 않되, 한/영 키는 다른 기능이 없으므로 소비한다.
+                    if type == .keyDown && !controller.isCurrentAppLocked() {
+                        os_log("Hangul key intercepted (keyDown), toggling%{public}@",
+                               log: log, type: .default,
+                               KeyEventTap.activeController == nil ? " [lastController fallback]" : "")
+                        DispatchQueue.main.async {
+                            controller.performToggleFromTap()
+                        }
+                    }
+                    return nil
+                }
+
                 // === flagsChanged: CapsLock 기반 한영 TOGGLE ===
                 // CapsLock은 하드웨어 토글이므로 ToggleDetector를 사용하지 않고
                 // flagsChanged에서 직접 감지하되, 다른 전환 키와 동일한 TOGGLE로 처리한다.

--- a/OngeulApp/Sources/OngeulInputController.swift
+++ b/OngeulApp/Sources/OngeulInputController.swift
@@ -132,6 +132,7 @@ private final class PreferencesPanel {
         toggleKeyTitles = [
             (.rightCommand, NSLocalizedString("prefs.toggleKey.rightCommand", comment: "")),
             (.rightOption,  NSLocalizedString("prefs.toggleKey.rightOption", comment: "")),
+            (.hangulKey,    NSLocalizedString("prefs.toggleKey.hangulKey", comment: "")),
             (.leftShift,    NSLocalizedString("prefs.toggleKey.leftShift", comment: "")),
             (.rightShift,   NSLocalizedString("prefs.toggleKey.rightShift", comment: "")),
             (.shiftSpace,   NSLocalizedString("prefs.toggleKey.shiftSpace", comment: "")),
@@ -1088,7 +1089,7 @@ class OngeulInputController: IMKInputController {
         client: any IMKTextInput
     ) -> Bool {
         switch action {
-        case .shiftSpaceToggle:
+        case .shiftSpaceToggle, .hangulKeyToggle:
             guard let effect = coordinator.toggleMode(for: currentBundleId)
             else { return false }
             applyEffect(effect, to: client)

--- a/OngeulApp/Sources/OngeulInputController.swift
+++ b/OngeulApp/Sources/OngeulInputController.swift
@@ -932,35 +932,37 @@ class OngeulInputController: IMKInputController {
 
     // MARK: - Private: Toggle / Lock / Vim Escape (KeyEventTap entry points)
 
+    /// doc 34: flip은 client와 무관하게 수행한다 (엔진은 전역 싱글턴). client는 부수 효과
+    /// (조합 flush 삽입, selectMode)에만 필요하며, 없으면 applyEffect가 폐기/이연 처리한다.
+    /// 예전처럼 client() guard로 flip 자체를 막으면 IMK 세션 공백(앱 자가업데이트 후 재실행
+    /// 등)에서 토글이 로그 없이 죽는다.
     func performToggleFromTap() {
-        guard let client: any IMKTextInput = self.client(),
-              let effect = coordinator.toggleMode(for: currentBundleId)
-        else { return }
-        applyEffect(effect, to: client)
+        guard let effect = coordinator.toggleMode(for: currentBundleId) else { return }
+        applyEffect(effect, to: self.client())
     }
 
     /// KeyEventTap의 CapsLock flagsChanged 분기에서 호출 (doc 30 SET 의미론).
     /// `korean: true` ⇒ 한글 모드 SET, `false` ⇒ 영문 모드 SET.
     /// 사용자가 CapsLock을 누른 결과 LED 상태를 입력 모드에 반영하는 단방향 SET.
+    /// client 없이도 SET은 수행한다 (doc 34).
     func performCapsLockModeSet(korean: Bool) {
-        guard let client: any IMKTextInput = self.client(),
-              let effect = coordinator.setModeFromCapsLockPress(
-                  korean: korean, for: currentBundleId
-              )
-        else { return }
-        applyEffect(effect, to: client)
+        guard let effect = coordinator.setModeFromCapsLockPress(
+            korean: korean, for: currentBundleId
+        ) else { return }
+        applyEffect(effect, to: self.client())
     }
 
     /// CapsLockHIDMonitor의 길게-누름 임계 발화에서 호출 (doc 32).
     /// 본연 CapsLock 활성화 = 영문 모드 SET + alpha-lock ON.
     /// macOS native parity: 길게 누르면 항상 *uppercase English* 환경 (현재 모드 무관).
+    /// client 없이도 SET+LED는 수행한다 (doc 34) — 호출자인 HID 모니터는 이미 자기 상태
+    /// 머신을 realLockOn으로 전이시킨 뒤라, 여기서 중단하면 모니터/엔진/LED가 drift한다.
     func performEnterRealCapsLock() {
-        guard let client: any IMKTextInput = self.client() else { return }
         // 영문 모드로 SET (현재 모드 무관). setMode가 syncCapsLock=false라 LED 안 건드림.
         if let effect = coordinator.setModeFromCapsLockPress(
             korean: false, for: currentBundleId
         ) {
-            applyEffect(effect, to: client)
+            applyEffect(effect, to: self.client())
         }
         // .hidRealLockOn 게이트가 active이므로 doc 30 mode-sync는 LED를 안 건드림 →
         // 본연 CapsLock LED를 직접 ON으로 set.
@@ -971,17 +973,42 @@ class OngeulInputController: IMKInputController {
     /// 진입 직전 모드로 복원 + LED OFF.
     /// 예: "한글 → 길게 → 영문+caps → 짧은 탭"이 한국어 + LED OFF로 환원되어 단일 동작 시퀀스 완결.
     /// LED는 HID 모드에서 *본연 CapsLock 활성 여부* 만을 표현하므로, 복원된 모드와 무관하게 항상 OFF.
+    /// client 없이도 복원+LED는 수행한다 (doc 34) — enter와 동일한 drift 방지.
     func performExitRealCapsLock(restoreMode: InputMode) {
-        guard let client: any IMKTextInput = self.client() else { return }
         let korean = (restoreMode == .korean)
         // 모드 복원 (setMode가 syncCapsLock=false + HID 모드라 LED는 안 만짐).
         if let effect = coordinator.setModeFromCapsLockPress(
             korean: korean, for: currentBundleId
         ) {
-            applyEffect(effect, to: client)
+            applyEffect(effect, to: self.client())
         }
         // LED는 항상 OFF — HID 모드에서 LED = realLockOn 표시 전용.
         CapsLockSync.setState(false)
+    }
+
+    /// 탭 콜백에서 resolvedController가 전혀 없을 때의 정적 flip 경로 (doc 34).
+    /// 엔진은 전역 싱글턴이므로 flip에 컨트롤러/client가 불필요하다. English Lock은
+    /// coordinator.isLocked가 판정하고(`isLocked(nil) == false`), 조합 flush 결과는 죽은
+    /// 세션의 것이므로 폐기해도 안전하다(doc 34 안전성 증명). TIS/아이콘 동기화는 tisDirty
+    /// 플래그를 통해 다음 activateServer가 청산한다.
+    static func performStaticToggleFromTap() {
+        guard let effect = coordinator.toggleMode(for: coordinator.activeAppBundleId)
+        else { return }
+        os_log("static flip (no controller): mode → %{public}@ (dropped commit=%d)",
+               log: log, type: .default,
+               coordinator.mode == .korean ? "korean" : "english",
+               effect.processResult?.committed != nil ? 1 : 0)
+    }
+
+    /// CapsLock flagsChanged의 정적 SET 경로 (doc 34). performStaticToggleFromTap과 동일 근거.
+    static func performStaticCapsLockModeSet(korean: Bool) {
+        guard let effect = coordinator.setModeFromCapsLockPress(
+            korean: korean, for: coordinator.activeAppBundleId
+        ) else { return }
+        os_log("static capsLock SET (no controller): mode → %{public}@ (dropped commit=%d)",
+               log: log, type: .default,
+               coordinator.mode == .korean ? "korean" : "english",
+               effect.processResult?.committed != nil ? 1 : 0)
     }
 
     func performVimEscapeFromTap() {
@@ -1204,9 +1231,18 @@ class OngeulInputController: IMKInputController {
         }
     }
 
-    private func applyEffect(_ effect: StateEffect, to client: any IMKTextInput) {
+    /// client가 nil이어도 호출 가능 (doc 34): flip/전역 상태는 이미 coordinator에서 완료된
+    /// 뒤이므로, client가 필요한 부수 효과만 폐기(조합 flush)하거나 이연(selectMode —
+    /// fireSelectMode가 발화 시점에 client를 재확인)한다.
+    private func applyEffect(_ effect: StateEffect, to client: (any IMKTextInput)?) {
         if let result = effect.processResult {
-            applyResult(result, to: client)
+            if let client {
+                applyResult(result, to: client)
+            } else {
+                // client 없음 = 그 조합이 속한 세션이 죽음 (doc 34 안전성 증명) → 폐기 안전.
+                os_log("applyEffect without client: flush dropped (committed=%d)",
+                       log: log, type: .error, result.committed != nil ? 1 : 0)
+            }
         }
         if effect.modeChanged {
             os_log("mode → %{public}@", log: log, type: .default,

--- a/OngeulApp/Sources/OngeulInputController.swift
+++ b/OngeulApp/Sources/OngeulInputController.swift
@@ -685,19 +685,24 @@ class OngeulInputController: IMKInputController {
             Self.chromiumAppCache[bundleId] = Self.isChromiumBased(bundleId: bundleId)
         }
 
+        let systemMode = Self.currentSystemInputMode()
         let effect = coordinator.activateApp(
             bundleId: bundleId,
-            systemMode: Self.currentSystemInputMode()
+            systemMode: systemMode
         )
         refreshLockCache()
         if let client = sender as? (any IMKTextInput) {
             applyEffect(effect, to: client)
         }
 
-        // 아이콘 동기화 — applyEffect의 modeChanged와 무관하게 항상 수행.
-        // 이전 client에 대한 보류된 selectMode는 stale이므로 폐기.
+        // 아이콘 동기화 — 단, 시스템 입력 소스가 이미 현재 모드와 일치하면 selectMode를
+        // 호출하지 않는다. Chromium 계열 앱(Chrome, Claude 데스크톱)은 selectMode로 입력
+        // 소스를 (재)assert하면 IMK 세션을 deactivate→activate로 재생성하는데, 그 재활성화가
+        // 다시 이 selectMode를 호출해 ~10Hz 피드백 루프(menu() 폭주)를 만들고 그 사이 키
+        // 입력이 deactivate 틈으로 유실된다. 모드가 실제로 어긋났을 때만 1회 갱신하면,
+        // 갱신 직후 systemMode가 일치하게 되어 다음 activate에서 루프가 끊긴다.
         cancelSelectMode()
-        if let client = sender as? (any IMKTextInput) {
+        if systemMode != coordinator.mode, let client = sender as? (any IMKTextInput) {
             let modeId = InputModeID.from(coordinator.mode)
             client.selectMode(modeId)
         }

--- a/OngeulApp/Sources/ToggleKey.swift
+++ b/OngeulApp/Sources/ToggleKey.swift
@@ -7,8 +7,10 @@ enum ToggleKey: String, CaseIterable {
     case rightShift = "rightShift"
     case shiftSpace = "shiftSpace"
     case capsLock = "capsLock"
+    case hangulKey = "hangulKey"
 
-    /// flagsChanged에서 감지할 keyCode (shiftSpace, capsLock은 nil → 별도 경로에서 처리)
+    /// flagsChanged에서 감지할 keyCode
+    /// (shiftSpace, capsLock, hangulKey는 nil → keyDown 등 별도 경로에서 처리)
     var keyCode: UInt16? {
         switch self {
         case .rightCommand: return KeyCode.rightCommand
@@ -17,6 +19,7 @@ enum ToggleKey: String, CaseIterable {
         case .rightShift:   return KeyCode.rightShift
         case .shiftSpace:   return nil
         case .capsLock:     return nil   // CGEventTap 콜백에서 직접 처리
+        case .hangulKey:    return nil   // keyDown(keycode 104)에서 직접 처리
         }
     }
 
@@ -28,6 +31,7 @@ enum ToggleKey: String, CaseIterable {
         case .leftShift, .rightShift: return .shift
         case .shiftSpace:   return nil
         case .capsLock:     return nil
+        case .hangulKey:    return nil
         }
     }
 }

--- a/OngeulTests/HandleKeyDownRouterTests.swift
+++ b/OngeulTests/HandleKeyDownRouterTests.swift
@@ -23,6 +23,36 @@ class HandleKeyDownRouterTests: XCTestCase {
         XCTAssertEqual(action, .space)
     }
 
+    func testHangulKeyToggle_koreanMode() {
+        // 한/영 전용 키(keycode 104) + hangulKey 모드 → 토글
+        let action = routeKeyDown(
+            keyCode: KeyCode.hangul, characters: nil,
+            modifiers: [], engineMode: .korean,
+            toggleKey: .hangulKey
+        )
+        XCTAssertEqual(action, .hangulKeyToggle)
+    }
+
+    func testHangulKeyToggle_englishMode() {
+        // 영문→한글 전환이 가능해야 하므로 영문 early-return보다 먼저 매칭되어야 한다.
+        let action = routeKeyDown(
+            keyCode: KeyCode.hangul, characters: nil,
+            modifiers: [], engineMode: .english,
+            toggleKey: .hangulKey
+        )
+        XCTAssertEqual(action, .hangulKeyToggle)
+    }
+
+    func testHangulKey_notActiveForOtherToggleKey() {
+        // hangulKey 모드가 아니면 keycode 104는 토글하지 않는다 (영문 모드 → passToSystem).
+        let action = routeKeyDown(
+            keyCode: KeyCode.hangul, characters: nil,
+            modifiers: [], engineMode: .english,
+            toggleKey: .rightCommand
+        )
+        XCTAssertEqual(action, .passToSystem)
+    }
+
     func testEnglishModePassthrough() {
         let action = routeKeyDown(
             keyCode: 0x05, characters: "g",

--- a/ongeul-update/src/version.rs
+++ b/ongeul-update/src/version.rs
@@ -5,7 +5,10 @@ fn compare_base(a: &str, b: &str) -> Ordering {
     // 컴포넌트 수를 cap하여 악의적/오류 버전 문자열의 unbounded 할당 방지.
     // 실제 semver는 3~4 컴포넌트이므로 8개면 충분히 여유.
     let parse = |v: &str| -> Vec<u32> {
-        v.split('.').take(8).filter_map(|s| s.parse().ok()).collect()
+        v.split('.')
+            .take(8)
+            .filter_map(|s| s.parse().ok())
+            .collect()
     };
     let a_parts = parse(a);
     let b_parts = parse(b);


### PR DESCRIPTION
External Korean keyboards send keycode 104 (kVK_JIS_Kana) for the dedicated 한/영 key. Add a `.hangulKey` toggle option that intercepts it to switch Korean/English mode, mirroring the shiftSpace dual-path design: CGEventTap is authoritative (consumes keyDown/keyUp so 104 does not leak to the app or system input-source switch), with an IMK routeKeyDown(.hangulKeyToggle) fallback when Accessibility is not granted.

- KeyCode.hangul (0x68); ToggleKey.hangulKey case (keyCode/flag nil → keyDown path)
- KeyEventTap branch respects hasLiveClient + English Lock, like shiftSpace
- Settings popup entry + ko/en localization
- Router unit tests: korean/english mode toggle + other-toggle-key guard

---

Also includes two toggle-resilience fixes on the same code paths (design doc 34):

**fix(ime): skip redundant selectMode to break Chromium activate loop** (3ce761d)
Chromium-based apps (Chrome, Claude desktop) recreate the IMK session on selectMode, which re-triggers activateServer's icon sync and forms a ~10Hz feedback loop that drops keystrokes. Only call selectMode when the system input source actually mismatches the engine mode.

**fix(ime): flip Han/Yeong toggle even without a live IMK client** (cf60236)
Toggle keys could silently die when no controller/client was reachable (e.g. an app relaunching after a self-update leaves an IMK session gap): the modifier-tap and CapsLock paths had no IMK fallback, and the entry points held the mode flip hostage to `self.client()`.

- Perform the flip before the `client()` guard in the tap entry points; `applyEffect` takes an optional client and drops the dead session's flush (logged) while selectMode defers to the next activateServer. Also fixes HID monitor state drift when real-CapsLock enter/exit fired with no client.
- Static flip fallbacks for the event-tap modifier and CapsLock branches when `resolvedController` is nil and Ongeul is the active input source.
- `tisDirty` flag in InputStateCoordinator so activateApp's TIS-priority rule does not roll back — and persist via per-app saveMode — a flip that selectMode has not yet propagated to TIS. Also closes the same rollback window in the selectMode debounce and Chromium activate churn.
- All previously silent failure points now log.

Verified: `build.sh` full build + `xcodebuild test` (98 tests) green.
